### PR TITLE
Fix Firebase workflows to build from code directory

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,10 +11,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: code/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: code
+      - name: Build
+        run: npm run build
+        working-directory: code
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREATIVE_ATLAS }}
           channelId: live
           projectId: creative-atlas
+          entryPoint: code

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,9 +13,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: npm run build
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+          cache-dependency-path: code/package-lock.json
+      - name: Install dependencies
+        run: npm ci
+        working-directory: code
+      - name: Build
+        run: npm run build
+        working-directory: code
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREATIVE_ATLAS }}
           projectId: creative-atlas
+          entryPoint: code


### PR DESCRIPTION
## Summary
- set up Node.js and install dependencies inside the `code` workspace before building
- run the production build from the `code` directory and point Firebase deploys at that entry point

## Testing
- npm ci
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ff805562e48328af335648bd8cd0e2