### PR TITLE
Fix Gemini client configuration

### DIFF
--- a/code/services/geminiService.ts
+++ b/code/services/geminiService.ts
@@ -12,7 +12,7 @@ const getClient = (): GoogleGenAI => {
   }
 
   if (!cachedClient) {
-    cachedClient = new GoogleGenAI({ apiKey, vertexai: true });
+    cachedClient = new GoogleGenAI({ apiKey });
   }
 
   return cachedClient;


### PR DESCRIPTION
## Summary
- stop forcing the Google GenAI client to use the Vertex AI endpoint so API-key auth works as expected

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ff80ddd09c832897ed85399c4fc5d9