### PR TITLE
Update AGENT guidelines for Vite prototype

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,11 +3,19 @@
 Welcome to the creative-atlas repository! Please follow these guidelines when making changes within this project:
 
 ## Repository-wide Conventions
-- Run `npm test` before opening a pull request to ensure the test suite passes.
-- Use `npm run lint` to check linting status.
+- The interactive prototype lives in `code/` and is a Vite + React + TypeScript app. Make all frontend changes inside that directory unless a task specifies otherwise.
+- Run `npm install` inside `code/` the first time you work in this repo so the Vite toolchain is available.
+- Use `npm run build` from `code/` before opening a pull request. It runs the TypeScript compiler and catches most integration issues for this prototype.
+- If you add or rename npm scripts, document them in `README.md` so others know how to run them.
 - Favor descriptive variable and function names; avoid abbreviations that are not widely understood.
 - Keep commits focused and well-described in their messages.
 - Update documentation in `README.md` or relevant files if behavior changes.
+
+## Frontend Code Style (code/)
+- Components are written as React function components in TypeScript. Follow that pattern unless there is a strong reason not to.
+- Tailwind-style utility classes are used extensively; keep styling changes consistent with the existing class-based approach.
+- Share reusable UI through the existing `components/` folder. Create new files rather than adding large inline components inside other files when functionality grows.
+- Domain models live in `code/types.ts`. When you extend data structures, update the corresponding TypeScript types and any mock data in `App.tsx` to keep the prototype consistent.
 
 ## Pull Requests
 - Provide a concise summary of the changes along with any notable implementation details.


### PR DESCRIPTION
## Summary
- update the root AGENTS.md to describe the Vite + React + TypeScript app that lives under `code/`
- add frontend style and domain modeling guidance based on the current component and type organization
- replace outdated npm test/lint instructions with accurate setup and build steps

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffb0e843cc8328b77bb608b54b64da