### PR TITLE
Add artifact filtering controls and task editor

### DIFF
--- a/code/components/GraphView.tsx
+++ b/code/components/GraphView.tsx
@@ -22,11 +22,12 @@ const nodeColor = (type: ArtifactType): string => {
 
 const GraphView: React.FC<GraphViewProps> = ({ artifacts, onNodeClick }) => {
   const { nodes, edges } = useMemo(() => {
+    const artifactIds = new Set(artifacts.map((artifact) => artifact.id));
     const initialNodes: Node[] = artifacts.map((artifact, i) => ({
       id: artifact.id,
       data: { label: artifact.title, type: artifact.type },
       position: { x: (i % 6) * 190 + Math.random() * 40, y: Math.floor(i / 6) * 140 + Math.random() * 40 },
-      style: { 
+      style: {
           background: '#1e293b', // slate-800
           color: '#e2e8f0', // slate-200
           border: `1px solid ${nodeColor(artifact.type)}`,
@@ -39,14 +40,16 @@ const GraphView: React.FC<GraphViewProps> = ({ artifacts, onNodeClick }) => {
     const initialEdges: Edge[] = [];
     artifacts.forEach(sourceArtifact => {
       sourceArtifact.relations.forEach(relation => {
-        initialEdges.push({
-          id: `e-${sourceArtifact.id}-${relation.toId}`,
-          source: sourceArtifact.id,
-          target: relation.toId,
-          animated: true,
-          label: relation.kind.replace(/_/g, ' ').toLowerCase(),
-          style: { stroke: '#64748b', strokeWidth: 1.5 }, // slate-500
-        });
+        if (artifactIds.has(relation.toId)) {
+          initialEdges.push({
+            id: `e-${sourceArtifact.id}-${relation.toId}`,
+            source: sourceArtifact.id,
+            target: relation.toId,
+            animated: true,
+            label: relation.kind.replace(/_/g, ' ').toLowerCase(),
+            style: { stroke: '#64748b', strokeWidth: 1.5 }, // slate-500
+          });
+        }
       });
     });
 

--- a/code/components/Icons.tsx
+++ b/code/components/Icons.tsx
@@ -122,3 +122,10 @@ export const FolderPlusIcon: React.FC<{ className?: string }> = ({ className }) 
         <path d='M2 10.75a.75.75 0 00-1.5 0v4.5A1.75 1.75 0 002.25 17h5a.75.75 0 000-1.5h-5a.25.25 0 01-.25-.25v-4.5z' />
     </svg>
 );
+
+export const CalendarIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
+        <path d='M6 2.75a.75.75 0 00-1.5 0V4H3.5A1.5 1.5 0 002 5.5v11A1.5 1.5 0 003.5 18h13a1.5 1.5 0 001.5-1.5v-11A1.5 1.5 0 0016.5 4H15V2.75a.75.75 0 00-1.5 0V4h-7V2.75z' />
+        <path d='M3.5 7.75a.75.75 0 01.75-.75h11a.75.75 0 010 1.5h-11a.75.75 0 01-.75-.75zM6.75 10a.75.75 0 000 1.5h1.5A.75.75 0 009 10h-.007A.75.75 0 006.75 10zm0 3a.75.75 0 000 1.5h1.5A.75.75 0 009 13h-.007A.75.75 0 006.75 13zm4-3a.75.75 0 000 1.5h1.5a.75.75 0 00.75-.75h-.007A.75.75 0 0010.75 10zm0 3a.75.75 0 000 1.5h1.5a.75.75 0 00.75-.75h-.007A.75.75 0 0010.75 13z' />
+    </svg>
+);

--- a/code/components/TaskEditor.tsx
+++ b/code/components/TaskEditor.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Artifact, TaskData, TaskState } from '../types';
+import { CalendarIcon, CheckCircleIcon, UserCircleIcon } from './Icons';
+
+interface TaskEditorProps {
+  artifact: Artifact;
+  onUpdateArtifactData: (artifactId: string, data: TaskData) => void;
+}
+
+const TaskEditor: React.FC<TaskEditorProps> = ({ artifact, onUpdateArtifactData }) => {
+  const initialData = (artifact.data as TaskData) ?? { state: TaskState.Todo };
+  const [taskState, setTaskState] = useState<TaskState>(initialData.state ?? TaskState.Todo);
+  const [assignee, setAssignee] = useState<string>(initialData.assignee ?? '');
+  const [due, setDue] = useState<string>(initialData.due ?? '');
+
+  useEffect(() => {
+    const currentData = (artifact.data as TaskData) ?? { state: TaskState.Todo };
+    setTaskState(currentData.state ?? TaskState.Todo);
+    setAssignee(currentData.assignee ?? '');
+    setDue(currentData.due ?? '');
+  }, [artifact.id, artifact.data]);
+
+  const updateTaskData = (updates: Partial<TaskData>) => {
+    const next: TaskData = {
+      state: taskState,
+      assignee,
+      due,
+      ...updates,
+    };
+    setTaskState(next.state ?? TaskState.Todo);
+    setAssignee(next.assignee ?? '');
+    setDue(next.due ?? '');
+    onUpdateArtifactData(artifact.id, next);
+  };
+
+  const dueInsight = useMemo(() => {
+    if (!due) {
+      return null;
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const dueDate = new Date(due);
+    if (Number.isNaN(dueDate.getTime())) {
+      return {
+        tone: 'neutral' as const,
+        message: 'Unable to parse due date.',
+      };
+    }
+
+    const dayDiff = Math.round((dueDate.getTime() - today.getTime()) / (1000 * 60 * 60 * 24));
+
+    if (dayDiff < 0) {
+      return {
+        tone: 'danger' as const,
+        message: `Overdue by ${Math.abs(dayDiff)} day${Math.abs(dayDiff) === 1 ? '' : 's'}.`,
+      };
+    }
+
+    if (dayDiff === 0) {
+      return {
+        tone: 'warning' as const,
+        message: 'Due today. Time to ship! 🚀',
+      };
+    }
+
+    if (dayDiff <= 3) {
+      return {
+        tone: 'warning' as const,
+        message: `Due in ${dayDiff} day${dayDiff === 1 ? '' : 's'}.`,
+      };
+    }
+
+    return {
+      tone: 'success' as const,
+      message: `Due in ${dayDiff} days. Plenty of runway.`,
+    };
+  }, [due]);
+
+  return (
+    <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700/50 space-y-6">
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <h3 className="text-xl font-bold text-emerald-400 flex items-center gap-2">
+          <CheckCircleIcon className="w-6 h-6" />
+          Quest Task Controls
+        </h3>
+        <div className="text-xs uppercase tracking-wide text-slate-400 bg-slate-900/60 border border-slate-700 rounded-full px-3 py-1">
+          {artifact.summary || 'No task summary yet.'}
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <span className="text-xs font-semibold text-slate-400 uppercase tracking-wide">Status</span>
+        <div className="flex flex-wrap gap-2">
+          {Object.values(TaskState).map((stateOption) => {
+            const isActive = stateOption === taskState;
+            return (
+              <button
+                key={stateOption}
+                onClick={() => updateTaskData({ state: stateOption })}
+                className={`px-3 py-1.5 text-sm font-semibold rounded-md border transition-colors ${
+                  isActive
+                    ? 'bg-emerald-600 text-white border-emerald-500 shadow-lg shadow-emerald-500/30'
+                    : 'bg-slate-900/60 text-slate-300 border-slate-700 hover:border-emerald-400/70 hover:text-emerald-200'
+                }`}
+                type="button"
+              >
+                {stateOption}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <div className="space-y-2">
+          <label htmlFor="task-assignee" className="text-xs font-semibold text-slate-400 uppercase tracking-wide">
+            Assignee
+          </label>
+          <div className="relative">
+            <UserCircleIcon className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
+            <input
+              id="task-assignee"
+              type="text"
+              value={assignee}
+              onChange={(event) => updateTaskData({ assignee: event.target.value })}
+              placeholder="Who is taking point?"
+              className="w-full bg-slate-900/60 border border-slate-700 rounded-md pl-9 pr-3 py-2 text-slate-200 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          <label htmlFor="task-due" className="text-xs font-semibold text-slate-400 uppercase tracking-wide">
+            Due Date
+          </label>
+          <div className="flex items-center gap-2">
+            <div className="relative flex-1">
+              <CalendarIcon className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
+              <input
+                id="task-due"
+                type="date"
+                value={due}
+                onChange={(event) => updateTaskData({ due: event.target.value })}
+                className="w-full bg-slate-900/60 border border-slate-700 rounded-md pl-9 pr-3 py-2 text-slate-200 focus:ring-2 focus:ring-emerald-500 focus:border-emerald-500 transition"
+              />
+            </div>
+            {due && (
+              <button
+                type="button"
+                onClick={() => updateTaskData({ due: '' })}
+                className="px-3 py-2 text-xs font-semibold text-slate-300 bg-slate-700/60 hover:bg-slate-700 rounded-md transition-colors"
+              >
+                Clear
+              </button>
+            )}
+          </div>
+          {dueInsight && (
+            <p
+              className={`text-xs mt-1 ${
+                dueInsight.tone === 'danger'
+                  ? 'text-red-400'
+                  : dueInsight.tone === 'warning'
+                  ? 'text-amber-300'
+                  : dueInsight.tone === 'success'
+                  ? 'text-emerald-300'
+                  : 'text-slate-400'
+              }`}
+            >
+              {dueInsight.message}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default TaskEditor;
+


### PR DESCRIPTION
## Summary
- add project-level artifact filters for type, stage, and text search with quick reset messaging
- surface filtered artifact counts and warn when the selected artifact is hidden by current filters
- introduce a dedicated task editor with assignee and due date controls plus enhanced relation management options

## Testing
- npm test *(fails: Missing script)*
- npm run lint *(fails: Missing script)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffb16fa2888328b13809c71b3f9d63