### PR TITLE
Add roadmap, template library, and AI copilot panels

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useMemo, useCallback, useRef } from 'react';
-import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, Scene, TaskData, TaskState, CharacterData, WikiData, LocationData } from './types';
+import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, Scene, TaskData, TaskState, CharacterData, WikiData, LocationData, TemplateCategory, Milestone, AIAssistant } from './types';
 import { CubeIcon, BookOpenIcon, PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon } from './components/Icons';
 import Modal from './components/Modal';
 import CreateArtifactForm from './components/CreateArtifactForm';
@@ -20,6 +20,9 @@ import { exportArtifactsToCSV, exportArtifactToMarkdown, exportProjectAsStaticSi
 import { importArtifactsFromCSV } from './utils/import';
 import ProjectInsights from './components/ProjectInsights';
 import { getStatusClasses, formatStatusLabel } from './utils/status';
+import TemplateGallery from './components/TemplateGallery';
+import Roadmap from './components/Roadmap';
+import AICopilotPanel from './components/AICopilotPanel';
 
 // Mock data based on the product spec
 const initialProjects: Project[] = [
@@ -50,6 +53,185 @@ const achievements: Achievement[] = [
     { id: 'ach-2', title: 'Polyglot', description: 'Create a Conlang artifact.', isUnlocked: (artifacts) => artifacts.some(a => a.type === ArtifactType.Conlang) },
     { id: 'ach-3', title: 'Cartographer', description: 'Create a Location artifact.', isUnlocked: (artifacts) => artifacts.some(a => a.type === ArtifactType.Location) },
     { id: 'ach-4', title: 'Connector', description: 'Link 3 artifacts together.', isUnlocked: (artifacts) => artifacts.reduce((acc, a) => acc + a.relations.length, 0) >= 3 },
+];
+
+const templateLibrary: TemplateCategory[] = [
+    {
+        id: 'tamenzut',
+        title: 'Tamenzut Series',
+        description: 'High-fantasy seeds that keep the Tamenzut saga consistent from novel to novel.',
+        recommendedFor: ['Tamenzut'],
+        templates: [
+            { id: 'tam-magic-system', name: 'MagicSystem', description: 'Document the laws, costs, and taboos of threadweaving.', tags: ['magic', 'systems'] },
+            { id: 'tam-rulebook', name: 'Rulebook', description: 'Capture canon rulings, rituals, and battle procedures.', tags: ['canon', 'reference'] },
+            { id: 'tam-city', name: 'City', description: 'Map out districts, factions, and sensory details for a key metropolis.', tags: ['location'] },
+            { id: 'tam-faction', name: 'Faction', description: 'Describe loyalties, resources, and political goals.', tags: ['faction', 'relationships'] },
+            { id: 'tam-edruel', name: 'Edruel Ruins', description: 'Archaeological log for the ruin that anchors the main mystery.', tags: ['lore'] },
+            { id: 'tam-thread-log', name: 'ThreadWeaving Log', description: 'Track legendary spells, their casters, and outcomes.', tags: ['magic', 'log'] },
+            { id: 'tam-canon', name: 'Canon Tracker', description: 'Record continuity-sensitive facts, pronunciations, and prophecies.', tags: ['continuity'] },
+        ],
+    },
+    {
+        id: 'steamweave',
+        title: 'Steamweave / Anya',
+        description: 'Coal-punk ops boards for Anya’s guild drama and gadgeteering.',
+        recommendedFor: ['Steamweave'],
+        templates: [
+            { id: 'steam-clan', name: 'Clan', description: 'Roster clan leadership, ranks, and rivalries.', tags: ['faction'] },
+            { id: 'steam-workshop', name: 'Workshop', description: 'Layout stations, ongoing inventions, and supply flows.', tags: ['location', 'operations'] },
+            { id: 'steam-scene', name: 'Scene', description: 'Storyboard high-tension coal-punk set pieces.', tags: ['story'] },
+            { id: 'steam-villain', name: 'Villain (Red-Eyes)', description: 'Profile motives, tactics, and weaknesses of Red-Eyes.', tags: ['character', 'antagonist'] },
+            { id: 'steam-triangle', name: 'Love Triangle Map', description: 'Visualize relationship beats and emotional stakes.', tags: ['relationships'] },
+            { id: 'steam-release', name: 'Release Notes', description: 'Translate updates into flavorful patch notes for collaborators.', tags: ['delivery'] },
+        ],
+    },
+    {
+        id: 'dustland',
+        title: 'Dustland RPG',
+        description: 'Questline scaffolds for the Dustland tabletop campaign.',
+        recommendedFor: ['Dustland'],
+        templates: [
+            { id: 'dust-module', name: 'Module', description: 'Outline module scope, level bands, and key beats.', tags: ['campaign'] },
+            { id: 'dust-quest', name: 'Quest', description: 'Track objectives, rewards, and branching outcomes.', tags: ['quest'] },
+            { id: 'dust-mask', name: 'Persona Mask', description: 'Detail roleplay cues, mannerisms, and secret agendas.', tags: ['npc'] },
+            { id: 'dust-npc', name: 'NPC', description: 'Profile allies, merchants, and nemeses with quick hooks.', tags: ['npc'] },
+            { id: 'dust-item', name: 'Item', description: 'Catalog relics, crafting components, and upgrades.', tags: ['loot'] },
+            { id: 'dust-tileset', name: 'Tileset', description: 'Collect reusable battle maps and environmental hazards.', tags: ['maps'] },
+            { id: 'dust-build', name: 'Build', description: 'Record character progressions and loadouts for playtests.', tags: ['characters'] },
+        ],
+    },
+    {
+        id: 'spatch',
+        title: 'Spatch League',
+        description: 'Sports-drama templates tuned for the Spatch comic universe.',
+        recommendedFor: ['Spatch'],
+        templates: [
+            { id: 'spatch-team', name: 'Team', description: 'Roster starters, strategies, and rival teams.', tags: ['team'] },
+            { id: 'spatch-mentor', name: 'Mentor', description: 'Capture training montages, philosophies, and signature drills.', tags: ['character'] },
+            { id: 'spatch-rule', name: 'Rule Variant', description: 'Document variant mechanics and how they change match flow.', tags: ['rules'] },
+            { id: 'spatch-match', name: 'Match', description: 'Plan panels, momentum swings, and highlight reels.', tags: ['story'] },
+            { id: 'spatch-board', name: 'Panel Board', description: 'Block out page layouts and pacing for episodes.', tags: ['storyboard'] },
+        ],
+    },
+    {
+        id: 'darv',
+        title: 'Darv Conlang',
+        description: 'Linguistic workbench for the ancient language of the Darv.',
+        recommendedFor: ['Darv'],
+        templates: [
+            { id: 'darv-lexicon', name: 'Lexicon', description: 'List lemmas, glosses, and phonological notes.', tags: ['language'] },
+            { id: 'darv-phonology', name: 'Phonology', description: 'Summarize phonemes, clusters, and stress rules.', tags: ['language'] },
+            { id: 'darv-paradigm', name: 'Paradigm', description: 'Lay out conjugation or declension tables.', tags: ['grammar'] },
+            { id: 'darv-proverb', name: 'Proverb', description: 'Capture idioms with cultural context and translations.', tags: ['culture'] },
+            { id: 'darv-myth', name: 'Myth', description: 'Outline myths and legends tied to linguistic lore.', tags: ['story'] },
+        ],
+    },
+    {
+        id: 'sacred-truth',
+        title: 'Sacred Truth Dossiers',
+        description: 'Supernatural investigation kits for the Sacred Truth vampire saga.',
+        recommendedFor: ['Sacred Truth'],
+        templates: [
+            { id: 'sacred-episode', name: 'Episode', description: 'Structure case-of-the-week arcs with cold opens and cliffhangers.', tags: ['story'] },
+            { id: 'sacred-case', name: 'Case File', description: 'Log evidence, suspects, and unresolved leads.', tags: ['mystery'] },
+            { id: 'sacred-codex', name: 'Monster Codex', description: 'Detail monster biology, tells, and encounter best practices.', tags: ['bestiary'] },
+            { id: 'sacred-cathedral', name: 'Cathedral Asset', description: 'Catalog lairs, safe houses, and relic vaults.', tags: ['location'] },
+        ],
+    },
+];
+
+const milestoneRoadmap: Milestone[] = [
+    {
+        id: 'm1',
+        title: 'M1 — MVP',
+        timeline: 'Weeks 1–4',
+        focus: 'Ship the graph-native core so ideas can be captured, linked, and exported.',
+        objectives: [
+            'Core graph model, Projects/Artifacts/Relations',
+            'Seed capture, Table view, basic Graph view',
+            'CSV import/export (artifacts, relations)',
+            'GitHub read-only import (repos/issues/releases)',
+        ],
+    },
+    {
+        id: 'm2',
+        title: 'M2 — Editors & Gamification',
+        timeline: 'Weeks 5–8',
+        focus: 'Deepen creation flows with rich editors and playful progression loops.',
+        objectives: [
+            'Conlang table editor; Storyboard; Kanban',
+            'XP/Streaks/Quests + Achievements',
+            'Markdown bundle export',
+        ],
+    },
+    {
+        id: 'm3',
+        title: 'M3 — Publishing & Integrations',
+        timeline: 'Weeks 9–12',
+        focus: 'Publish worlds outward with search, release tooling, and static sites.',
+        objectives: [
+            'Static site exporter (Wikis/Docs)',
+            'Release notes generator',
+            'Search (Meilisearch), advanced filters',
+        ],
+    },
+    {
+        id: 'm4',
+        title: 'M4 — Polish & Extensibility',
+        timeline: 'Weeks 13–16',
+        focus: 'Open the universe with plugins, theming, and offline-friendly polish.',
+        objectives: [
+            'Plugin API + 3 sample plugins (conlang, webcomic, ai prompts)',
+            'Theming, keyboard palette, offline cache (light)',
+        ],
+    },
+];
+
+const aiAssistants: AIAssistant[] = [
+    {
+        id: 'lore-weaver',
+        name: 'Lore Weaver',
+        description: 'Expands summaries, suggests links, and weaves conflict matrices so the universe feels alive.',
+        focus: 'Narrative expansion & connective tissue',
+        promptSlots: [
+            'synth_outline(projectId, artifactId, tone, constraints)',
+            'link_matrix(projectId, focusArtifactId)',
+            'conflict_web(projectId)',
+        ],
+    },
+    {
+        id: 'conlang-smith',
+        name: 'Conlang Smith',
+        description: 'Batches lexemes, paradigm tables, and example sentences to grow fictional languages fast.',
+        focus: 'Language design & lexicon growth',
+        promptSlots: [
+            'lexeme_seed(conlangId, phonotactics, needed_pos)',
+            'paradigm_table(conlangId, partOfSpeech)',
+            'example_sentences(conlangId, register)',
+        ],
+    },
+    {
+        id: 'story-doctor',
+        name: 'Story Doctor',
+        description: 'Diagnoses beats, tension curves, and recommends comp titles for strong narrative pacing.',
+        focus: 'Story health & pacing diagnostics',
+        promptSlots: [
+            'beat_diagnostic(projectId, artifactId)',
+            'tension_graph(projectId, artifactId)',
+            'comp_titles(genre, wordcount)',
+        ],
+    },
+    {
+        id: 'release-bard',
+        name: 'Release Bard',
+        description: 'Turns changelogs into narrative release notes and scripts launch trailers.',
+        focus: 'Publishing voice & launch storytelling',
+        promptSlots: [
+            'patch_notes(repo, tag_range, audience)',
+            'release_story(projectId, milestoneId, tone)',
+            'trailer_script(projectId, duration)',
+        ],
+    },
 ];
 
 const Header: React.FC<{ xp: number }> = ({ xp }) => (
@@ -503,6 +685,13 @@ export default function App() {
                     )}
                 </div>
               )}
+              <div className="grid grid-cols-1 xl:grid-cols-2 gap-6 mt-8">
+                <TemplateGallery categories={templateLibrary} activeProjectTitle={selectedProject.title} />
+                <AICopilotPanel assistants={aiAssistants} />
+                <div className="xl:col-span-2">
+                    <Roadmap milestones={milestoneRoadmap} />
+                </div>
+              </div>
             </>
           ) : (
             <div className="flex items-center justify-center h-full bg-slate-800/50 rounded-lg border border-dashed border-slate-700">

--- a/code/components/AICopilotPanel.tsx
+++ b/code/components/AICopilotPanel.tsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { AIAssistant } from '../types';
+import { SparklesIcon, BookOpenIcon } from './Icons';
+
+interface AICopilotPanelProps {
+  assistants: AIAssistant[];
+}
+
+const AICopilotPanel: React.FC<AICopilotPanelProps> = ({ assistants }) => {
+  const [activeId, setActiveId] = useState<string>(assistants[0]?.id ?? '');
+  const activeAssistant = assistants.find((assistant) => assistant.id === activeId) ?? assistants[0];
+
+  return (
+    <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-5">
+      <header className="flex items-center gap-3">
+        <SparklesIcon className="w-5 h-5 text-pink-400" />
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">AI Copilots</h3>
+          <p className="text-sm text-slate-400">
+            Four opt-in copilots stand ready with prompt slots tuned to Creative Atlas workflows. Swap between them to preview their specialities.
+          </p>
+        </div>
+      </header>
+
+      <div className="flex flex-col lg:flex-row gap-4">
+        <nav className="flex lg:flex-col gap-2 lg:w-48">
+          {assistants.map((assistant) => {
+            const isActive = assistant.id === activeAssistant?.id;
+            return (
+              <button
+                key={assistant.id}
+                onClick={() => setActiveId(assistant.id)}
+                className={`text-left px-3 py-2 rounded-lg border text-sm font-semibold transition-colors ${
+                  isActive
+                    ? 'bg-pink-600/30 border-pink-500/60 text-pink-200 shadow-lg shadow-pink-900/20'
+                    : 'bg-slate-900/60 border-slate-700/60 text-slate-300 hover:border-pink-400/60'
+                }`}
+              >
+                {assistant.name}
+              </button>
+            );
+          })}
+        </nav>
+
+        {activeAssistant && (
+          <article className="flex-1 bg-slate-900/70 border border-slate-700/60 rounded-xl p-4 space-y-4">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Focus</p>
+              <h4 className="text-lg font-semibold text-slate-100">{activeAssistant.focus}</h4>
+            </div>
+            <p className="text-sm text-slate-300">{activeAssistant.description}</p>
+            <div className="space-y-3">
+              <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+                <BookOpenIcon className="w-4 h-4 text-cyan-300" />
+                Prompt Slots
+              </div>
+              <ul className="space-y-2 text-sm text-slate-200">
+                {activeAssistant.promptSlots.map((slot) => (
+                  <li key={slot} className="bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2 font-mono text-xs">
+                    {slot}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </article>
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default AICopilotPanel;

--- a/code/components/Icons.tsx
+++ b/code/components/Icons.tsx
@@ -129,3 +129,15 @@ export const CalendarIcon: React.FC<{ className?: string }> = ({ className }) =>
         <path d='M3.5 7.75a.75.75 0 01.75-.75h11a.75.75 0 010 1.5h-11a.75.75 0 01-.75-.75zM6.75 10a.75.75 0 000 1.5h1.5A.75.75 0 009 10h-.007A.75.75 0 006.75 10zm0 3a.75.75 0 000 1.5h1.5A.75.75 0 009 13h-.007A.75.75 0 006.75 13zm4-3a.75.75 0 000 1.5h1.5a.75.75 0 00.75-.75h-.007A.75.75 0 0010.75 10zm0 3a.75.75 0 000 1.5h1.5a.75.75 0 00.75-.75h-.007A.75.75 0 0010.75 13z' />
     </svg>
 );
+
+export const MagnifyingGlassIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
+        <path fillRule='evenodd' d='M9 3.5a5.5 5.5 0 014.356 8.89l2.932 2.932a.75.75 0 11-1.06 1.06l-2.932-2.932A5.5 5.5 0 119 3.5zm0 1.5a4 4 0 100 8 4 4 0 000-8z' clipRule='evenodd' />
+    </svg>
+);
+
+export const FlagIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
+        <path fillRule='evenodd' d='M3.75 2A.75.75 0 013 2.75v14.5a.75.75 0 001.5 0v-4.03c.399-.186.84-.22 1.276-.087l.805.241c1.172.351 2.42.267 3.545-.238a4.978 4.978 0 012.716-.357l2.05.341A.75.75 0 0015.75 12V3.25a.75.75 0 00-.88-.737l-2.477.413a4.478 4.478 0 01-2.506.327l-1.28-.256A5.977 5.977 0 005.5 3.5a4.5 4.5 0 01-1.75-.35V2.75A.75.75 0 013.75 2z' clipRule='evenodd' />
+    </svg>
+);

--- a/code/components/Roadmap.tsx
+++ b/code/components/Roadmap.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Milestone } from '../types';
+import { FlagIcon, SparklesIcon } from './Icons';
+
+interface RoadmapProps {
+  milestones: Milestone[];
+}
+
+const Roadmap: React.FC<RoadmapProps> = ({ milestones }) => {
+  return (
+    <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
+      <header className="flex items-center gap-3">
+        <FlagIcon className="w-5 h-5 text-amber-400" />
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">Milestone Roadmap</h3>
+          <p className="text-sm text-slate-400">
+            Track how Creative Atlas levels up across the first 16 weeks. Each milestone unlocks new layers of the creative stack.
+          </p>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {milestones.map((milestone) => (
+          <article
+            key={milestone.id}
+            className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-4 space-y-3 shadow-lg shadow-slate-950/20"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{milestone.timeline}</p>
+                <h4 className="text-lg font-semibold text-slate-200">{milestone.title}</h4>
+              </div>
+              <SparklesIcon className="w-5 h-5 text-violet-400" />
+            </div>
+            <p className="text-sm text-slate-400">{milestone.focus}</p>
+            <ul className="space-y-2 text-sm text-slate-300">
+              {milestone.objectives.map((objective) => (
+                <li
+                  key={objective}
+                  className="flex items-start gap-2 bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2"
+                >
+                  <span className="mt-0.5 text-cyan-300">•</span>
+                  <span>{objective}</span>
+                </li>
+              ))}
+            </ul>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+};
+
+export default Roadmap;

--- a/code/components/TemplateGallery.tsx
+++ b/code/components/TemplateGallery.tsx
@@ -1,0 +1,135 @@
+import React, { useMemo, useState } from 'react';
+import { TemplateCategory } from '../types';
+import { MagnifyingGlassIcon, SparklesIcon } from './Icons';
+
+interface TemplateGalleryProps {
+  categories: TemplateCategory[];
+  activeProjectTitle?: string;
+}
+
+const TemplateGallery: React.FC<TemplateGalleryProps> = ({ categories, activeProjectTitle }) => {
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const { recommended, others } = useMemo(() => {
+    const normalizedQuery = searchTerm.trim().toLowerCase();
+    const filtered = categories.filter((category) => {
+      if (!normalizedQuery) return true;
+      const haystack = [
+        category.title,
+        category.description,
+        ...category.templates.map((template) => `${template.name} ${template.description} ${template.tags?.join(' ') ?? ''}`),
+      ]
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(normalizedQuery);
+    });
+
+    if (!activeProjectTitle) {
+      return {
+        recommended: [],
+        others: filtered,
+      };
+    }
+
+    const recommendedCategories = filtered.filter((category) =>
+      category.recommendedFor.some((name) => name.toLowerCase() === activeProjectTitle.toLowerCase())
+    );
+    const recommendedIds = new Set(recommendedCategories.map((category) => category.id));
+    const otherCategories = filtered.filter((category) => !recommendedIds.has(category.id));
+
+    return {
+      recommended: recommendedCategories,
+      others: otherCategories,
+    };
+  }, [categories, searchTerm, activeProjectTitle]);
+
+  const renderCategoryCard = (category: TemplateCategory, isRecommended: boolean) => (
+    <div
+      key={category.id}
+      className="bg-slate-900/50 border border-slate-700/60 rounded-xl p-4 space-y-3 hover:border-cyan-500/60 transition-colors"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <h4 className="text-lg font-semibold text-slate-100 flex items-center gap-2">
+            {isRecommended && <SparklesIcon className="w-4 h-4 text-cyan-400" />}
+            {category.title}
+          </h4>
+          <p className="text-sm text-slate-400 mt-1">{category.description}</p>
+        </div>
+        {isRecommended && (
+          <span className="text-xs font-semibold uppercase tracking-wide text-cyan-300 bg-cyan-900/50 border border-cyan-700/40 rounded-full px-2 py-1">
+            Recommended
+          </span>
+        )}
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {category.templates.map((template) => (
+          <div key={template.id} className="bg-slate-800/50 border border-slate-700/50 rounded-lg p-3">
+            <h5 className="text-sm font-semibold text-slate-200">{template.name}</h5>
+            <p className="text-xs text-slate-400 mt-1">{template.description}</p>
+            {template.tags && template.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-3">
+                {template.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="text-[10px] uppercase tracking-wide text-slate-400 bg-slate-900/60 border border-slate-700 rounded-full px-2 py-0.5"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+
+  return (
+    <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
+      <header className="flex flex-col gap-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-300 uppercase tracking-wide">
+          <SparklesIcon className="w-5 h-5 text-cyan-400" />
+          Template Library
+        </div>
+        <p className="text-sm text-slate-400">
+          Jump-start new artifacts with ready-made scaffolds tuned for recurring universes and genres. Search or pick from the
+          curated sets below.
+        </p>
+        <div className="relative">
+          <MagnifyingGlassIcon className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />
+          <input
+            type="search"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Search templates..."
+            className="w-full bg-slate-900/80 border border-slate-700 rounded-lg pl-9 pr-3 py-2 text-sm text-slate-200 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+          />
+        </div>
+      </header>
+
+      {recommended.length > 0 && (
+        <div className="space-y-4">
+          <div className="text-xs font-semibold text-cyan-300 uppercase tracking-wide">Tailored for {activeProjectTitle}</div>
+          <div className="space-y-4">
+            {recommended.map((category) => renderCategoryCard(category, true))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {recommended.length > 0 && (
+          <div className="text-xs font-semibold text-slate-400 uppercase tracking-wide">More creative kits</div>
+        )}
+        <div className="space-y-4">
+          {others.map((category) => renderCategoryCard(category, false))}
+          {recommended.length === 0 && others.length === 0 && (
+            <p className="text-sm text-slate-500">No templates match that search just yet. Try a different keyword.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default TemplateGallery;

--- a/code/types.ts
+++ b/code/types.ts
@@ -112,3 +112,34 @@ export interface Achievement {
     description: string;
     isUnlocked: (artifacts: Artifact[], projects: Project[]) => boolean;
 }
+
+export interface TemplateEntry {
+    id: string;
+    name: string;
+    description: string;
+    tags?: string[];
+}
+
+export interface TemplateCategory {
+    id: string;
+    title: string;
+    description: string;
+    recommendedFor: string[];
+    templates: TemplateEntry[];
+}
+
+export interface Milestone {
+    id: string;
+    title: string;
+    timeline: string;
+    focus: string;
+    objectives: string[];
+}
+
+export interface AIAssistant {
+    id: string;
+    name: string;
+    description: string;
+    focus: string;
+    promptSlots: string[];
+}


### PR DESCRIPTION
## Summary
- add a template library panel that highlights universe-specific starter kits
- surface the milestone roadmap and AI copilot prompt slots in dedicated panels
- extend shared types and icon set to support the new UI sections

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ffb326d9208328bb1476e3d8951941