### PR TITLE
Document auth completion and tighten profile state handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A playful, gamified personal knowledge system for organizing web comics, wikis, 
 - 📘 See [`docs/firebase-backend-migration.md`](docs/firebase-backend-migration.md) for the recommended Firebase + Firestore architecture and step-by-step migration plan (starting with authentication setup).
 
 ### Authentication, Authorization, and Profiles
-- [ ] Add sign-up and login flows with token-based authentication for the web client.
+- [x] Add sign-up and login flows with token-based authentication for the web client.
 - [ ] Associate every project and artifact with an owner and enforce row-level authorization rules.
 - [ ] Persist user-specific settings, XP totals, and achievements so progress follows accounts across devices.
 

--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useMemo, useCallback, useRef, KeyboardEvent, useEffect } from 'react';
-import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, Scene, TaskData, TaskState, CharacterData, WikiData, LocationData, TemplateCategory, Milestone, AIAssistant, UserProfile } from './types';
+import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, TaskData, TaskState, TemplateCategory, Milestone, AIAssistant, UserProfile } from './types';
 import { CubeIcon, BookOpenIcon, PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon } from './components/Icons';
 import Modal from './components/Modal';
 import CreateArtifactForm from './components/CreateArtifactForm';
@@ -541,10 +541,10 @@ export default function App() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <Header profile={safeProfile} xpProgress={xpProgress} level={level} onSignOut={signOutUser} />
+      <Header profile={profile} xpProgress={xpProgress} level={level} onSignOut={signOutUser} />
       <main className="flex-grow grid grid-cols-1 lg:grid-cols-12 gap-8 p-4 sm:p-8">
         <aside className="lg:col-span-3 space-y-6">
-          <UserProfileCard profile={safeProfile} onUpdateProfile={handleProfileUpdate} />
+          <UserProfileCard profile={profile} onUpdateProfile={handleProfileUpdate} />
           <div>
             <div className="flex justify-between items-center px-2 mb-4">
                 <h2 className="text-lg font-semibold text-slate-300">Projects</h2>

--- a/code/contexts/UserDataContext.tsx
+++ b/code/contexts/UserDataContext.tsx
@@ -154,7 +154,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
     if (Object.keys(updates).length > 0) {
       setProfile((current) => (current ? { ...current, ...updates } : current));
     }
-  }, [user?.displayName, user?.photoURL, user?.email]);
+  }, [user, profile]);
 
   useEffect(() => {
     if (!user || !hydrated || !profile) return;
@@ -180,11 +180,11 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
   const updateProfile = useCallback((update: ProfileUpdate) => {
     setProfile((current) => {
       if (!current) return current;
-      const nextSettings = update.settings ? { ...current.settings, ...update.settings } : current.settings;
-      const nextAchievements = update.achievementsUnlocked
-        ? Array.from(new Set([...current.achievementsUnlocked, ...update.achievementsUnlocked]))
+      const { settings: partialSettings, achievementsUnlocked: unlockedIds, ...rest } = update;
+      const nextSettings = partialSettings ? { ...current.settings, ...partialSettings } : current.settings;
+      const nextAchievements = unlockedIds
+        ? Array.from(new Set([...current.achievementsUnlocked, ...unlockedIds]))
         : current.achievementsUnlocked;
-      const { settings, achievementsUnlocked, ...rest } = update;
       return {
         ...current,
         ...rest,


### PR DESCRIPTION
## Summary
- mark the authentication milestone as complete in the product spec README
- clean up the app shell to use the current profile directly and remove unused type imports
- adjust profile update logic in the user data context to satisfy lint dependencies and merge partial settings safely

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900406a3ce08328a8cd4f64481b6b1e