### PR TITLE
Add project overview management panel

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -18,6 +18,7 @@ import LocationEditor from './components/LocationEditor';
 import TaskEditor from './components/TaskEditor';
 import { exportArtifactsToCSV, exportArtifactsToTSV, exportProjectAsStaticSite } from './utils/export';
 import { importArtifactsFromCSV } from './utils/import';
+import ProjectOverview from './components/ProjectOverview';
 import ProjectInsights from './components/ProjectInsights';
 import { getStatusClasses, formatStatusLabel } from './utils/status';
 import TemplateGallery from './components/TemplateGallery';
@@ -521,6 +522,10 @@ export default function App() {
   const hasActiveFilters = artifactTypeFilter !== 'ALL' || statusFilter !== 'ALL' || searchTerm.trim() !== '';
   const filteredSelectedArtifactHidden = Boolean(selectedArtifact && !filteredArtifacts.some(artifact => artifact.id === selectedArtifact.id));
 
+  const handleUpdateProject = useCallback((projectId: string, updater: (project: Project) => Project) => {
+    setProjects(currentProjects => currentProjects.map(project => project.id === projectId ? updater(project) : project));
+  }, [setProjects]);
+
   if (!profile) {
     return null;
   }
@@ -579,6 +584,10 @@ export default function App() {
         <section className="lg:col-span-9 space-y-8">
           {selectedProject ? (
             <>
+              <ProjectOverview
+                  project={selectedProject}
+                  onUpdateProject={handleUpdateProject}
+              />
               <ProjectInsights artifacts={projectArtifacts} />
               <GitHubImportPanel
                   projectId={selectedProject.id}

--- a/code/components/Icons.tsx
+++ b/code/components/Icons.tsx
@@ -156,3 +156,10 @@ export const FlagIcon: React.FC<{ className?: string }> = ({ className }) => (
         <path fillRule='evenodd' d='M3.75 2A.75.75 0 013 2.75v14.5a.75.75 0 001.5 0v-4.03c.399-.186.84-.22 1.276-.087l.805.241c1.172.351 2.42.267 3.545-.238a4.978 4.978 0 012.716-.357l2.05.341A.75.75 0 0015.75 12V3.25a.75.75 0 00-.88-.737l-2.477.413a4.478 4.478 0 01-2.506.327l-1.28-.256A5.977 5.977 0 005.5 3.5a4.5 4.5 0 01-1.75-.35V2.75A.75.75 0 013.75 2z' clipRule='evenodd' />
     </svg>
 );
+
+export const TagIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
+        <path d='M17.28 10.22l-6.5-6.5A1.75 1.75 0 009.54 3H4.25A1.75 1.75 0 002.5 4.75v5.29c0 .464.184.91.513 1.237l6.5 6.5a1.75 1.75 0 002.474 0l5.293-5.293a1.75 1.75 0 000-2.474z' />
+        <path d='M6.25 7.5a1.25 1.25 0 111.5-2 1.25 1.25 0 01-1.5 2z' />
+    </svg>
+);

--- a/code/components/ProjectOverview.tsx
+++ b/code/components/ProjectOverview.tsx
@@ -1,0 +1,224 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Project, ProjectStatus } from '../types';
+import { formatStatusLabel, getStatusClasses } from '../utils/status';
+import { TagIcon, XMarkIcon } from './Icons';
+
+interface ProjectOverviewProps {
+  project: Project;
+  onUpdateProject: (projectId: string, updater: (project: Project) => Project) => void;
+}
+
+const statusOrder: ProjectStatus[] = [
+  ProjectStatus.Idea,
+  ProjectStatus.Active,
+  ProjectStatus.Paused,
+  ProjectStatus.Archived,
+];
+
+const ProjectOverview: React.FC<ProjectOverviewProps> = ({ project, onUpdateProject }) => {
+  const [isEditingSummary, setIsEditingSummary] = useState(false);
+  const [summaryDraft, setSummaryDraft] = useState(project.summary);
+  const [summaryError, setSummaryError] = useState<string | null>(null);
+  const [tagInput, setTagInput] = useState('');
+  const [tagError, setTagError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSummaryDraft(project.summary);
+    setIsEditingSummary(false);
+    setSummaryError(null);
+    setTagInput('');
+    setTagError(null);
+  }, [project.id, project.summary]);
+
+  const tagCount = useMemo(() => project.tags.length, [project.tags]);
+
+  const handleStatusChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextStatus = event.target.value as ProjectStatus;
+    if (nextStatus === project.status) return;
+    onUpdateProject(project.id, (current) => ({ ...current, status: nextStatus }));
+  };
+
+  const handleSummarySubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmed = summaryDraft.trim();
+    if (!trimmed) {
+      setSummaryError('Summary cannot be empty.');
+      return;
+    }
+    onUpdateProject(project.id, (current) => ({ ...current, summary: trimmed }));
+    setSummaryError(null);
+    setIsEditingSummary(false);
+  };
+
+  const handleCancelSummary = () => {
+    setSummaryDraft(project.summary);
+    setSummaryError(null);
+    setIsEditingSummary(false);
+  };
+
+  const handleAddTag = () => {
+    const trimmed = tagInput.trim();
+    if (!trimmed) {
+      setTagError('Enter a tag before adding it.');
+      return;
+    }
+
+    onUpdateProject(project.id, (current) => {
+      const exists = current.tags.some((tag) => tag.toLowerCase() === trimmed.toLowerCase());
+      if (exists) {
+        setTagError('That tag is already attached to this project.');
+        return current;
+      }
+      return { ...current, tags: [...current.tags, trimmed] };
+    });
+
+    setTagInput('');
+    setTagError(null);
+  };
+
+  const handleRemoveTag = (tagToRemove: string) => {
+    onUpdateProject(project.id, (current) => ({
+      ...current,
+      tags: current.tags.filter((tag) => tag !== tagToRemove),
+    }));
+  };
+
+  const handleTagKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      handleAddTag();
+    }
+  };
+
+  return (
+    <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
+      <header className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
+        <div>
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Project Overview</p>
+          <h2 className="text-2xl font-bold text-white mt-1">{project.title}</h2>
+          <p className="text-xs text-slate-500 mt-2 font-mono break-all">ID: {project.id}</p>
+        </div>
+        <div className="flex flex-col items-start gap-2 sm:flex-row sm:items-center">
+          <span className={`inline-flex items-center px-3 py-1 text-xs font-semibold rounded-full ${getStatusClasses(project.status)}`}>
+            {formatStatusLabel(project.status)}
+          </span>
+          <select
+            value={project.status}
+            onChange={handleStatusChange}
+            className="bg-slate-800/80 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+          >
+            {statusOrder.map((status) => (
+              <option key={status} value={status}>
+                {formatStatusLabel(status)}
+              </option>
+            ))}
+          </select>
+        </div>
+      </header>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-slate-300 uppercase tracking-wide">Summary</h3>
+          {!isEditingSummary && (
+            <button
+              type="button"
+              onClick={() => setIsEditingSummary(true)}
+              className="text-xs font-semibold text-cyan-300 hover:text-cyan-200"
+            >
+              Edit summary
+            </button>
+          )}
+        </div>
+        {isEditingSummary ? (
+          <form className="space-y-3" onSubmit={handleSummarySubmit}>
+            <textarea
+              value={summaryDraft}
+              onChange={(event) => {
+                setSummaryDraft(event.target.value);
+                if (summaryError) {
+                  setSummaryError(null);
+                }
+              }}
+              rows={3}
+              className="w-full bg-slate-900/70 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+            />
+            {summaryError && <p className="text-xs text-rose-300">{summaryError}</p>}
+            <div className="flex gap-2">
+              <button
+                type="submit"
+                className="px-3 py-1.5 text-xs font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors"
+              >
+                Save summary
+              </button>
+              <button
+                type="button"
+                onClick={handleCancelSummary}
+                className="px-3 py-1.5 text-xs font-semibold text-slate-200 bg-slate-800 hover:bg-slate-700 rounded-md transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          </form>
+        ) : (
+          <p className="text-sm text-slate-300 bg-slate-900/50 border border-slate-800 rounded-lg px-4 py-3">
+            {project.summary || 'No summary yet. Add one to give collaborators context.'}
+          </p>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-300 uppercase tracking-wide">
+          <TagIcon className="w-4 h-4 text-cyan-300" />
+          Tags
+          <span className="text-xs font-normal text-slate-500">({tagCount})</span>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {project.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center gap-1 px-3 py-1 text-xs font-medium bg-slate-800/60 border border-slate-700/60 rounded-full text-slate-200"
+            >
+              {tag}
+              <button
+                type="button"
+                onClick={() => handleRemoveTag(tag)}
+                className="text-slate-400 hover:text-rose-300"
+                aria-label={`Remove ${tag}`}
+              >
+                <XMarkIcon className="w-3 h-3" />
+              </button>
+            </span>
+          ))}
+          {project.tags.length === 0 && (
+            <span className="text-xs text-slate-500">No tags yet. Add some to aid search and filtering.</span>
+          )}
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            type="text"
+            value={tagInput}
+            onChange={(event) => {
+              setTagInput(event.target.value);
+              if (tagError) {
+                setTagError(null);
+              }
+            }}
+            onKeyDown={handleTagKeyDown}
+            placeholder="Add a project tag and press Enter"
+            className="flex-1 bg-slate-900/70 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+          />
+          <button
+            type="button"
+            onClick={handleAddTag}
+            className="px-4 py-2 text-sm font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors"
+          >
+            Add tag
+          </button>
+        </div>
+        {tagError && <p className="text-xs text-rose-300">{tagError}</p>}
+      </div>
+    </section>
+  );
+};
+
+export default ProjectOverview;

--- a/code/utils/status.ts
+++ b/code/utils/status.ts
@@ -7,6 +7,10 @@ export const STATUS_STYLE_MAP: Record<string, string> = {
   beta: 'bg-indigo-900/40 text-indigo-100 border border-indigo-600/50',
   released: 'bg-emerald-900/40 text-emerald-100 border border-emerald-600/50',
   done: 'bg-emerald-900/40 text-emerald-100 border border-emerald-600/50',
+  active: 'bg-emerald-900/40 text-emerald-100 border border-emerald-600/50',
+  paused: 'bg-amber-900/40 text-amber-100 border border-amber-600/50',
+  archived: 'bg-slate-900/60 text-slate-300 border border-slate-700/60',
+  shipped: 'bg-sky-900/40 text-sky-100 border border-sky-600/50',
 };
 
 export const getStatusClasses = (status: string): string => {


### PR DESCRIPTION
## Summary
- add a project overview panel that lets creators edit summaries, status, and tags directly from the dashboard
- wire the new overview component into the main app and expose an updater helper for project mutations
- extend the shared icon set and status styling map to cover project stages and release metadata

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900d8763e7883289ad235eb6c9a048e