### PR TITLE
Add guest browsing mode for login bypass

### DIFF
--- a/code/components/AuthGate.tsx
+++ b/code/components/AuthGate.tsx
@@ -165,10 +165,10 @@ const AuthScreen: React.FC = () => {
 };
 
 const AuthGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
-  const { user, loading: authLoading } = useAuth();
+  const { user, loading: authLoading, isGuestMode } = useAuth();
   const { loading: dataLoading } = useUserData();
 
-  if (authLoading || (user && dataLoading)) {
+  if (authLoading || (!isGuestMode && user && dataLoading) || (isGuestMode && dataLoading)) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-slate-950 text-slate-300">
         <div className="animate-pulse text-center">
@@ -179,7 +179,7 @@ const AuthGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
     );
   }
 
-  if (!user) {
+  if (!user && !isGuestMode) {
     return <AuthScreen />;
   }
 

--- a/code/contexts/AuthContext.tsx
+++ b/code/contexts/AuthContext.tsx
@@ -16,6 +16,7 @@ interface SignInParams {
 interface AuthContextValue {
   user: User | null;
   loading: boolean;
+  isGuestMode: boolean;
   signUp: (params: SignUpParams) => Promise<void>;
   signIn: (params: SignInParams) => Promise<void>;
   signOutUser: () => Promise<void>;
@@ -25,11 +26,26 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
+const detectGuestMode = (): boolean => {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const params = new URLSearchParams(window.location.search);
+  return params.get('guest') === '1';
+};
+
 export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [isGuestMode] = useState(() => detectGuestMode());
 
   useEffect(() => {
+    if (isGuestMode) {
+      setUser(null);
+      setLoading(false);
+      return;
+    }
+
     const auth = getAuth();
     setPersistence(auth, browserLocalPersistence).catch((error) => {
       console.error('Failed to enable auth persistence', error);
@@ -41,46 +57,62 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     });
 
     return () => unsubscribe();
-  }, []);
+  }, [isGuestMode]);
 
   const signUp = useCallback(async ({ email, password, displayName }: SignUpParams) => {
+    if (isGuestMode) {
+      throw new Error('Guest mode does not support account creation.');
+    }
     const auth = getAuth();
     const credential = await createUserWithEmailAndPassword(auth, email, password);
     if (displayName.trim()) {
       await updateProfile(credential.user, { displayName });
     }
-  }, []);
+  }, [isGuestMode]);
 
   const signIn = useCallback(async ({ email, password }: SignInParams) => {
+    if (isGuestMode) {
+      throw new Error('Guest mode does not support authentication.');
+    }
     const auth = getAuth();
     await signInWithEmailAndPassword(auth, email, password);
-  }, []);
+  }, [isGuestMode]);
 
   const signOutUser = useCallback(async () => {
+    if (isGuestMode) {
+      return Promise.resolve();
+    }
     const auth = getAuth();
     await signOut(auth);
-  }, []);
+  }, [isGuestMode]);
 
   const signInWithGoogleProvider = useCallback(async () => {
+    if (isGuestMode) {
+      throw new Error('Guest mode does not support authentication.');
+    }
     const auth = getAuth();
     const provider = new GoogleAuthProvider();
     await signInWithPopup(auth, provider);
-  }, []);
+  }, [isGuestMode]);
 
   const updateDisplayName = useCallback(async (displayName: string) => {
+    if (isGuestMode) {
+      return Promise.resolve();
+    }
     if (!user) return;
     await updateProfile(user, { displayName });
-  }, [user]);
+  }, [user, isGuestMode]);
 
   const value = useMemo<AuthContextValue>(() => ({
     user,
     loading,
+    isGuestMode,
     signUp,
     signIn,
     signOutUser,
     signInWithGoogle: signInWithGoogleProvider,
     updateDisplayName,
-  }), [user, loading, signUp, signIn, signOutUser, signInWithGoogleProvider, updateDisplayName]);
+  }), [user, loading, isGuestMode, signUp, signIn, signOutUser, signInWithGoogleProvider, updateDisplayName]);
 
   return (
     <AuthContext.Provider value={value}>


### PR DESCRIPTION
## Summary
- add guest mode detection in the auth context that bypasses firebase auth when `?guest=1` is present
- allow the auth gate and user data provider to hydrate a temporary workspace so the app is usable without persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900db2785cc8328b3505b72e7cc7afe