### PR TITLE
Add collapsible user preferences panel

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -532,6 +532,7 @@ export default function App() {
 
   const xpProgress = profile.xp % 100;
   const level = Math.floor(profile.xp / 100) + 1;
+  const isViewingOwnWorkspace = !selectedProject || selectedProject.ownerId === profile.uid;
 
   const handleResetFilters = () => {
     setArtifactTypeFilter('ALL');
@@ -558,7 +559,9 @@ export default function App() {
       <Header profile={profile} xpProgress={xpProgress} level={level} onSignOut={signOutUser} />
       <main className="flex-grow grid grid-cols-1 lg:grid-cols-12 gap-8 p-4 sm:p-8">
         <aside className="lg:col-span-3 space-y-6">
-          <UserProfileCard profile={profile} onUpdateProfile={handleProfileUpdate} />
+          {isViewingOwnWorkspace && (
+            <UserProfileCard profile={profile} onUpdateProfile={handleProfileUpdate} />
+          )}
           <div>
             <div className="flex justify-between items-center px-2 mb-4">
                 <h2 className="text-lg font-semibold text-slate-300">Projects</h2>

--- a/code/components/Icons.tsx
+++ b/code/components/Icons.tsx
@@ -138,6 +138,12 @@ export const FolderPlusIcon: React.FC<{ className?: string }> = ({ className }) 
     </svg>
 );
 
+export const ChevronDownIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
+    <path fillRule='evenodd' d='M5.23 7.21a.75.75 0 011.06.02L10 10.94l3.71-3.71a.75.75 0 111.08 1.04l-4.24 4.25a.75.75 0 01-1.08 0L5.21 8.27a.75.75 0 01.02-1.06z' clipRule='evenodd' />
+  </svg>
+);
+
 export const CalendarIcon: React.FC<{ className?: string }> = ({ className }) => (
     <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
         <path d='M6 2.75a.75.75 0 00-1.5 0V4H3.5A1.5 1.5 0 002 5.5v11A1.5 1.5 0 003.5 18h13a1.5 1.5 0 001.5-1.5v-11A1.5 1.5 0 0016.5 4H15V2.75a.75.75 0 00-1.5 0V4h-7V2.75z' />

--- a/code/components/UserProfileCard.tsx
+++ b/code/components/UserProfileCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ThemePreference, UserProfile } from '../types';
 import { useAuth } from '../contexts/AuthContext';
+import { ChevronDownIcon } from './Icons';
 
 interface UserProfileCardProps {
   profile: UserProfile;
@@ -28,6 +29,7 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({ profile, onUpdateProf
   const [displayName, setDisplayName] = useState(profile.displayName);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
 
   useEffect(() => {
     setDisplayName(profile.displayName);
@@ -35,6 +37,10 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({ profile, onUpdateProf
 
   const level = useMemo(() => levelFromXp(profile.xp), [profile.xp]);
   const xpProgress = useMemo(() => progressFromXp(profile.xp), [profile.xp]);
+
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [profile.uid]);
 
   const handleNameSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -66,97 +72,112 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({ profile, onUpdateProf
   };
 
   return (
-    <section className="bg-slate-900/60 border border-slate-800 rounded-2xl p-5 space-y-5 shadow-lg shadow-slate-950/40">
-      <header className="flex items-center gap-3">
-        {profile.photoURL ? (
-          <img src={profile.photoURL} alt={profile.displayName} className="w-12 h-12 rounded-full object-cover border border-slate-700" />
-        ) : (
-          <div className="w-12 h-12 rounded-full bg-cyan-600/20 border border-cyan-500/40 flex items-center justify-center text-lg font-semibold text-cyan-200">
-            {initialsFromName(profile.displayName)}
+    <section className="bg-slate-900/60 border border-slate-800 rounded-2xl p-5 shadow-lg shadow-slate-950/40">
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          {profile.photoURL ? (
+            <img src={profile.photoURL} alt={profile.displayName} className="w-12 h-12 rounded-full object-cover border border-slate-700" />
+          ) : (
+            <div className="w-12 h-12 rounded-full bg-cyan-600/20 border border-cyan-500/40 flex items-center justify-center text-lg font-semibold text-cyan-200">
+              {initialsFromName(profile.displayName)}
+            </div>
+          )}
+          <div>
+            <p className="text-sm font-medium text-cyan-300">Creator Level {level}</p>
+            <h2 className="text-lg font-semibold text-white">{profile.displayName}</h2>
+            <p className="text-xs text-slate-400">{profile.email}</p>
           </div>
-        )}
-        <div>
-          <p className="text-sm font-medium text-cyan-300">Creator Level {level}</p>
-          <h2 className="text-lg font-semibold text-white">{profile.displayName}</h2>
-          <p className="text-xs text-slate-400">{profile.email}</p>
-        </div>
-      </header>
-
-      <div>
-        <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">Progress</p>
-        <div className="relative h-3 bg-slate-800 rounded-full overflow-hidden">
-          <div className="absolute inset-y-0 left-0 bg-gradient-to-r from-cyan-500 to-violet-500 transition-all duration-500" style={{ width: `${Math.min(xpProgress, 100)}%` }}></div>
-        </div>
-        <div className="flex justify-between text-xs text-slate-400 mt-1">
-          <span>{xpProgress} / 100 XP</span>
-          <span>Total XP: {profile.xp}</span>
-        </div>
-      </div>
-
-      <form onSubmit={handleNameSubmit} className="space-y-3">
-        <div>
-          <label htmlFor="display-name" className="block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-1">
-            Display name
-          </label>
-          <input
-            id="display-name"
-            type="text"
-            value={displayName}
-            onChange={(event) => setDisplayName(event.target.value)}
-            className="w-full px-3 py-2 rounded-md bg-slate-800 border border-slate-700 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500"
-          />
         </div>
         <button
-          type="submit"
-          className="w-full px-3 py-2 text-sm font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
-          disabled={saving}
+          type="button"
+          onClick={() => setIsExpanded((previous) => !previous)}
+          className="flex items-center gap-2 px-3 py-1 text-xs font-semibold text-cyan-200 bg-slate-800/70 hover:bg-slate-800 rounded-md transition-colors"
+          aria-expanded={isExpanded}
         >
-          {saving ? 'Saving…' : 'Save profile'}
+          {isExpanded ? 'Hide preferences' : 'Show preferences'}
+          <ChevronDownIcon className={`w-4 h-4 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
         </button>
-        {statusMessage && (
-          <p className="text-xs text-cyan-300" role="status">{statusMessage}</p>
-        )}
-      </form>
+      </header>
 
-      <div className="space-y-3">
-        <div>
-          <label htmlFor="theme" className="block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-1">
-            Theme preference
-          </label>
-          <select
-            id="theme"
-            value={profile.settings.theme}
-            onChange={handleThemeChange}
-            className="w-full px-3 py-2 rounded-md bg-slate-800 border border-slate-700 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500"
-          >
-            {themeOptions.map((option) => (
-              <option key={option.value} value={option.value}>{option.label}</option>
-            ))}
-          </select>
-        </div>
-        <div className="flex items-center justify-between">
+      {isExpanded && (
+        <div className="mt-5 space-y-5">
           <div>
-            <p className="text-sm font-semibold text-slate-200">AI copilots tips</p>
-            <p className="text-xs text-slate-400">{profile.settings.aiTipsEnabled ? 'Enabled' : 'Disabled'} for contextual suggestions.</p>
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">Progress</p>
+            <div className="relative h-3 bg-slate-800 rounded-full overflow-hidden">
+              <div className="absolute inset-y-0 left-0 bg-gradient-to-r from-cyan-500 to-violet-500 transition-all duration-500" style={{ width: `${Math.min(xpProgress, 100)}%` }}></div>
+            </div>
+            <div className="flex justify-between text-xs text-slate-400 mt-1">
+              <span>{xpProgress} / 100 XP</span>
+              <span>Total XP: {profile.xp}</span>
+            </div>
           </div>
-          <button
-            type="button"
-            onClick={handleAiTipsToggle}
-            className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border border-transparent transition-colors duration-200 ease-in-out ${profile.settings.aiTipsEnabled ? 'bg-cyan-500' : 'bg-slate-700'}`}
-            role="switch"
-            aria-checked={profile.settings.aiTipsEnabled}
-          >
-            <span
-              className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200 ease-in-out ${profile.settings.aiTipsEnabled ? 'translate-x-5' : 'translate-x-0'}`}
-            ></span>
-          </button>
-        </div>
-      </div>
 
-      <div className="flex items-center justify-between text-xs text-slate-400">
-        <span>Achievements synced: <span className="text-slate-200 font-semibold">{profile.achievementsUnlocked.length}</span></span>
-        <span>Last sync: Live</span>
-      </div>
+          <form onSubmit={handleNameSubmit} className="space-y-3">
+            <div>
+              <label htmlFor="display-name" className="block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-1">
+                Display name
+              </label>
+              <input
+                id="display-name"
+                type="text"
+                value={displayName}
+                onChange={(event) => setDisplayName(event.target.value)}
+                className="w-full px-3 py-2 rounded-md bg-slate-800 border border-slate-700 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500"
+              />
+            </div>
+            <button
+              type="submit"
+              className="w-full px-3 py-2 text-sm font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
+              disabled={saving}
+            >
+              {saving ? 'Saving…' : 'Save profile'}
+            </button>
+            {statusMessage && (
+              <p className="text-xs text-cyan-300" role="status">{statusMessage}</p>
+            )}
+          </form>
+
+          <div className="space-y-3">
+            <div>
+              <label htmlFor="theme" className="block text-xs font-semibold uppercase tracking-wide text-slate-400 mb-1">
+                Theme preference
+              </label>
+              <select
+                id="theme"
+                value={profile.settings.theme}
+                onChange={handleThemeChange}
+                className="w-full px-3 py-2 rounded-md bg-slate-800 border border-slate-700 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500"
+              >
+                {themeOptions.map((option) => (
+                  <option key={option.value} value={option.value}>{option.label}</option>
+                ))}
+              </select>
+            </div>
+            <div className="flex items-center justify-between">
+              <div>
+                <p className="text-sm font-semibold text-slate-200">AI copilots tips</p>
+                <p className="text-xs text-slate-400">{profile.settings.aiTipsEnabled ? 'Enabled' : 'Disabled'} for contextual suggestions.</p>
+              </div>
+              <button
+                type="button"
+                onClick={handleAiTipsToggle}
+                className={`relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border border-transparent transition-colors duration-200 ease-in-out ${profile.settings.aiTipsEnabled ? 'bg-cyan-500' : 'bg-slate-700'}`}
+                role="switch"
+                aria-checked={profile.settings.aiTipsEnabled}
+              >
+                <span
+                  className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition duration-200 ease-in-out ${profile.settings.aiTipsEnabled ? 'translate-x-5' : 'translate-x-0'}`}
+                ></span>
+              </button>
+            </div>
+          </div>
+
+          <div className="flex items-center justify-between text-xs text-slate-400">
+            <span>Achievements synced: <span className="text-slate-200 font-semibold">{profile.achievementsUnlocked.length}</span></span>
+            <span>Last sync: Live</span>
+          </div>
+        </div>
+      )}
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- add a chevron icon to support collapsible controls
- update the user profile card so XP and preferences live in a collapsed panel by default
- hide the profile panel when viewing a project owned by another creator

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900df894bb08328aff401ad183fc564