### PR TITLE
Add reusable project templates that seed starter artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A playful, gamified personal knowledge system for organizing web comics, wikis, 
 ### Phase 1 — Seed the Universe (Weeks 0‑4)
 - [ ] Deliver the Layer 1 capture flow: quick-create cards for ideas, characters, scenes, mechanics, and lexemes with inline tagging and lightweight linking.
 - [x] Move the XP/progression surface into a compact widget beside the creator portrait and collapse the full preferences + XP pane by default.
-- [ ] Add reusable project templates (comic, conlang, game design, wiki) that hydrate dashboards, tables, and starter artifacts.
+- [x] Add reusable project templates (comic, conlang, game design, wiki) that hydrate dashboards, tables, and starter artifacts.
 - [ ] Ensure changing projects resets AI-generated draft release notes so context stays accurate.
 
 ### Phase 2 — Grow Projects (Weeks 5‑8)

--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useMemo, useCallback, useRef, KeyboardEvent, useEffect } from 'react';
-import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, TaskData, TaskState, TemplateCategory, Milestone, AIAssistant, UserProfile } from './types';
+import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, TaskData, TaskState, TemplateCategory, Milestone, AIAssistant, UserProfile, ProjectTemplate } from './types';
 import { CubeIcon, BookOpenIcon, PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon, SparklesIcon } from './components/Icons';
 import Modal from './components/Modal';
 import CreateArtifactForm from './components/CreateArtifactForm';
@@ -22,6 +22,7 @@ import ProjectOverview from './components/ProjectOverview';
 import ProjectInsights from './components/ProjectInsights';
 import { getStatusClasses, formatStatusLabel } from './utils/status';
 import TemplateGallery from './components/TemplateGallery';
+import ProjectTemplatePicker from './components/ProjectTemplatePicker';
 import ReleaseNotesGenerator from './components/ReleaseNotesGenerator';
 import { useUserData } from './contexts/UserDataContext';
 import { useAuth } from './contexts/AuthContext';
@@ -126,6 +127,171 @@ const templateLibrary: TemplateCategory[] = [
         ],
     },
 ];
+
+const projectTemplates: ProjectTemplate[] = [
+    {
+        id: 'serial-comic-kit',
+        name: 'Serial Comic Kit',
+        description: 'Story arcs, cast rosters, and production tasks tuned for episodic comics.',
+        recommendedFor: ['Spatch', 'Steamweave'],
+        projectTags: ['comic', 'storyboard', 'production'],
+        artifacts: [
+            {
+                title: 'Season Roadmap',
+                type: ArtifactType.Story,
+                summary: 'Outline upcoming arcs, spotlight issues, and publishing cadence.',
+                status: 'draft',
+                tags: ['roadmap', 'issues'],
+            },
+            {
+                title: 'Cast Gallery',
+                type: ArtifactType.Character,
+                summary: 'Snapshot bios, motivations, and relationship notes for the main cast.',
+                status: 'idea',
+                tags: ['characters', 'reference'],
+            },
+            {
+                title: 'Issue Sprint Backlog',
+                type: ArtifactType.Task,
+                summary: 'Track page breakdowns, lettering, and marketing beats for the next drop.',
+                status: 'in-progress',
+                tags: ['sprint', 'release'],
+                data: { state: TaskState.InProgress } as TaskData,
+            },
+        ],
+    },
+    {
+        id: 'conlang-workbench',
+        name: 'Conlang Workbench',
+        description: 'Lexicon, grammar notes, and workflow tasks for language-building.',
+        recommendedFor: ['Tamenzut', 'Darv'],
+        projectTags: ['conlang', 'language'],
+        artifacts: [
+            {
+                title: 'Lexicon Seed',
+                type: ArtifactType.Conlang,
+                summary: 'Kick off vocabulary batches with phonotactics and thematic tags.',
+                status: 'draft',
+                tags: ['lexicon'],
+                data: [
+                    { id: 'tmpl-lex-1', lemma: 'salar', pos: 'n', gloss: 'ember-forged song' },
+                    { id: 'tmpl-lex-2', lemma: 'vith', pos: 'adj', gloss: 'woven with starlight' },
+                ] as ConlangLexeme[],
+            },
+            {
+                title: 'Grammar Notes',
+                type: ArtifactType.Wiki,
+                summary: 'Document morphology, syntax quirks, and inspiration languages.',
+                status: 'idea',
+                tags: ['reference'],
+                data: { content: '## Phonology\n- Consonant harmony sketch\n\n## Morphology\n- Case markers TBD' },
+            },
+            {
+                title: 'Phonology Recording Sprint',
+                type: ArtifactType.Task,
+                summary: 'Capture sound samples and finalize the consonant inventory.',
+                status: 'todo',
+                tags: ['audio', 'phonology'],
+            },
+        ],
+    },
+    {
+        id: 'game-design-lab',
+        name: 'Game Design Lab',
+        description: 'Gameplay loops, system glossaries, and playtest backlogs for interactive worlds.',
+        recommendedFor: ['Dustland'],
+        projectTags: ['game', 'systems'],
+        artifacts: [
+            {
+                title: 'Core Loop Prototype',
+                type: ArtifactType.Game,
+                summary: 'Define what players do minute-to-minute and the rewards that fuel repeat sessions.',
+                status: 'draft',
+                tags: ['core-loop', 'prototype'],
+            },
+            {
+                title: 'Mechanics Glossary',
+                type: ArtifactType.MagicSystem,
+                summary: 'Catalog resources, ability cooldowns, and failure states.',
+                status: 'idea',
+                tags: ['mechanics'],
+            },
+            {
+                title: 'Playtest Feedback Backlog',
+                type: ArtifactType.Task,
+                summary: 'Triage insights from the latest playtest into actionable follow-ups.',
+                status: 'in-progress',
+                tags: ['playtest'],
+                data: { state: TaskState.InProgress } as TaskData,
+            },
+            {
+                title: 'Design Log',
+                type: ArtifactType.Wiki,
+                summary: 'Chronicle key decisions, questions, and experiments.',
+                status: 'draft',
+                tags: ['journal'],
+                data: { content: '## Decisions\n- Note major pivots here\n\n## Open Questions\n- Capture follow-ups from playtests' },
+            },
+        ],
+    },
+    {
+        id: 'world-wiki-launchpad',
+        name: 'World Wiki Launchpad',
+        description: 'Knowledge base scaffolding for lore-heavy worlds and collaborative wikis.',
+        recommendedFor: ['Tamenzut', 'Sacred Truth'],
+        projectTags: ['wiki', 'lore'],
+        artifacts: [
+            {
+                title: 'World Encyclopedia',
+                type: ArtifactType.Wiki,
+                summary: 'Master index for timelines, factions, and canon checkpoints.',
+                status: 'draft',
+                tags: ['index'],
+                data: { content: '# World Encyclopedia\n\n## Overview\n- Establish tone and era\n\n## Canon Queue\n- Pending lore to verify' },
+            },
+            {
+                title: 'Starting Region Profile',
+                type: ArtifactType.Location,
+                summary: 'Describe the primary hub with landmarks, cultures, and conflicts.',
+                status: 'draft',
+                tags: ['location', 'hub'],
+                data: {
+                    description: 'Sketch the climate, sensory beats, and why this region matters to newcomers.',
+                    features: [
+                        { id: 'tmpl-feature-1', name: 'Beacon Market', description: 'Central plaza where rumors and quests surface.' },
+                    ],
+                },
+            },
+            {
+                title: 'Faction Briefs Backlog',
+                type: ArtifactType.Task,
+                summary: 'List the organizations you still need to document and their urgency.',
+                status: 'todo',
+                tags: ['factions', 'backlog'],
+            },
+        ],
+    },
+];
+
+const getDefaultDataForType = (type: ArtifactType, title?: string): Artifact['data'] => {
+    switch (type) {
+        case ArtifactType.Conlang:
+            return [];
+        case ArtifactType.Story:
+        case ArtifactType.Scene:
+            return [];
+        case ArtifactType.Task:
+            return { state: TaskState.Todo } as TaskData;
+        case ArtifactType.Character:
+            return { bio: '', traits: [] };
+        case ArtifactType.Wiki:
+            return { content: `# ${title ?? 'Untitled'}\n\n` };
+        case ArtifactType.Location:
+            return { description: '', features: [] };
+        default:
+            return {};
+    }
+};
 
 const milestoneRoadmap: Milestone[] = [
     {
@@ -412,13 +578,7 @@ export default function App() {
   const handleCreateArtifact = useCallback(({ title, type, summary }: { title: string; type: ArtifactType; summary: string }) => {
     if (!selectedProjectId || !profile) return;
 
-    let data: Artifact['data'] = {};
-    if (type === ArtifactType.Conlang) data = [];
-    if (type === ArtifactType.Story) data = [];
-    if (type === ArtifactType.Task) data = { state: TaskState.Todo };
-    if (type === ArtifactType.Character) data = { bio: '', traits: [] };
-    if (type === ArtifactType.Wiki) data = { content: `# ${title}\n\n` };
-    if (type === ArtifactType.Location) data = { description: '', features: [] };
+    const data: Artifact['data'] = getDefaultDataForType(type, title);
 
     const newArtifact: Artifact = {
       id: `art-${Date.now()}`,
@@ -438,6 +598,56 @@ export default function App() {
     setIsCreateModalOpen(false);
     setSelectedArtifactId(newArtifact.id);
   }, [profile, selectedProjectId, addXp, setArtifacts]);
+
+  const handleApplyProjectTemplate = useCallback((template: ProjectTemplate) => {
+    if (!profile || !selectedProjectId) return;
+
+    const projectArtifactsForSelection = artifacts.filter(artifact => artifact.projectId === selectedProjectId);
+    const existingTitles = new Set(projectArtifactsForSelection.map(artifact => artifact.title.toLowerCase()));
+    const timestamp = Date.now();
+
+    const newArtifacts = template.artifacts
+      .filter(blueprint => !existingTitles.has(blueprint.title.toLowerCase()))
+      .map((blueprint, index) => ({
+        id: `art-${timestamp + index}`,
+        ownerId: profile.uid,
+        projectId: selectedProjectId,
+        title: blueprint.title,
+        type: blueprint.type,
+        summary: blueprint.summary,
+        status: blueprint.status ?? 'draft',
+        tags: blueprint.tags ? [...blueprint.tags] : [],
+        relations: [],
+        data: blueprint.data ?? getDefaultDataForType(blueprint.type, blueprint.title),
+      }));
+
+    if (newArtifacts.length > 0) {
+      setArtifacts(prev => [...prev, ...newArtifacts]);
+      addXp(newArtifacts.length * 5);
+      setSelectedArtifactId(newArtifacts[0].id);
+      alert(`Added ${newArtifacts.length} starter artifact${newArtifacts.length > 1 ? 's' : ''} from the ${template.name} template.`);
+    } else {
+      alert('All of the template\'s starter artifacts already exist in this project.');
+    }
+
+    if (template.projectTags.length > 0) {
+      setProjects(prev => {
+        let changed = false;
+        const next = prev.map(project => {
+          if (project.id !== selectedProjectId) {
+            return project;
+          }
+          const mergedTags = Array.from(new Set([...project.tags, ...template.projectTags]));
+          if (mergedTags.length !== project.tags.length) {
+            changed = true;
+            return { ...project, tags: mergedTags };
+          }
+          return project;
+        });
+        return changed ? next : prev;
+      });
+    }
+  }, [profile, selectedProjectId, artifacts, setArtifacts, addXp, setProjects]);
 
   const handleImportClick = () => {
     fileInputRef.current?.click();
@@ -770,8 +980,16 @@ export default function App() {
                     )}
                 </div>
               )}
-              <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 mt-8">
-                <TemplateGallery categories={templateLibrary} activeProjectTitle={selectedProject.title} />
+              <div className="grid grid-cols-1 xl:grid-cols-4 gap-6 mt-8">
+                <div className="space-y-6 xl:col-span-2">
+                  <ProjectTemplatePicker
+                    templates={projectTemplates}
+                    activeProjectTitle={selectedProject.title}
+                    onApplyTemplate={handleApplyProjectTemplate}
+                    isApplyDisabled={!selectedProjectId}
+                  />
+                  <TemplateGallery categories={templateLibrary} activeProjectTitle={selectedProject.title} />
+                </div>
                 <ReleaseNotesGenerator
                     projectTitle={selectedProject.title}
                     artifacts={projectArtifacts}

--- a/code/components/ProjectTemplatePicker.tsx
+++ b/code/components/ProjectTemplatePicker.tsx
@@ -1,0 +1,118 @@
+import React, { useMemo } from 'react';
+import { ProjectTemplate } from '../types';
+import { FolderPlusIcon, SparklesIcon } from './Icons';
+
+interface ProjectTemplatePickerProps {
+  templates: ProjectTemplate[];
+  activeProjectTitle?: string;
+  onApplyTemplate: (template: ProjectTemplate) => void;
+  isApplyDisabled?: boolean;
+}
+
+const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
+  templates,
+  activeProjectTitle,
+  onApplyTemplate,
+  isApplyDisabled = false,
+}) => {
+  const { recommended, others } = useMemo(() => {
+    if (!activeProjectTitle) {
+      return { recommended: [], others: templates };
+    }
+
+    const recommendedTemplates = templates.filter((template) =>
+      template.recommendedFor?.some((name) => name.toLowerCase() === activeProjectTitle.toLowerCase())
+    );
+    const recommendedIds = new Set(recommendedTemplates.map((template) => template.id));
+    const otherTemplates = templates.filter((template) => !recommendedIds.has(template.id));
+
+    return { recommended: recommendedTemplates, others: otherTemplates };
+  }, [templates, activeProjectTitle]);
+
+  const renderTemplateCard = (template: ProjectTemplate, isRecommended: boolean) => (
+    <div
+      key={template.id}
+      className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-5 space-y-4 hover:border-cyan-500/50 transition-colors"
+    >
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h4 className="text-lg font-semibold text-slate-100 flex items-center gap-2">
+            {isRecommended && <SparklesIcon className="w-4 h-4 text-cyan-400" />}
+            {template.name}
+          </h4>
+          <p className="text-sm text-slate-400 mt-1">{template.description}</p>
+        </div>
+        {template.projectTags.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {template.projectTags.map((tag) => (
+              <span
+                key={tag}
+                className="text-[10px] uppercase tracking-wide text-slate-400 bg-slate-900/70 border border-slate-700 rounded-full px-2 py-0.5"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+      </header>
+
+      <div className="space-y-3">
+        {template.artifacts.map((artifact) => (
+          <div key={artifact.title} className="bg-slate-800/40 border border-slate-700/50 rounded-lg px-3 py-2">
+            <div className="text-sm font-semibold text-slate-200">{artifact.title}</div>
+            <div className="text-xs text-slate-400 uppercase tracking-wide">{artifact.type}</div>
+            <p className="text-xs text-slate-400 mt-1">{artifact.summary}</p>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => onApplyTemplate(template)}
+        disabled={isApplyDisabled}
+        className={`flex items-center justify-center gap-2 w-full px-4 py-2 text-sm font-semibold rounded-md transition-colors border
+          ${isApplyDisabled
+            ? 'cursor-not-allowed text-slate-500 bg-slate-800/80 border-slate-700'
+            : 'text-cyan-100 bg-cyan-600/80 hover:bg-cyan-500 border-cyan-500/60'
+          }`}
+      >
+        <FolderPlusIcon className="w-4 h-4" />
+        {isApplyDisabled ? 'Select a project to apply' : `Apply to ${activeProjectTitle ?? 'project'}`}
+      </button>
+    </div>
+  );
+
+  return (
+    <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
+      <header className="space-y-2">
+        <div className="flex items-center gap-2 text-sm font-semibold text-slate-300 uppercase tracking-wide">
+          <SparklesIcon className="w-5 h-5 text-cyan-400" />
+          Project Templates
+        </div>
+        <p className="text-sm text-slate-400">
+          Drop in curated starter artifacts to hydrate dashboards instantly. Existing entries are preserved—new templates only add what&apos;s missing.
+        </p>
+      </header>
+
+      {recommended.length > 0 && (
+        <div className="space-y-4">
+          <div className="text-xs font-semibold text-cyan-300 uppercase tracking-wide">Tailored for {activeProjectTitle}</div>
+          <div className="space-y-4">
+            {recommended.map((template) => renderTemplateCard(template, true))}
+          </div>
+        </div>
+      )}
+
+      <div className="space-y-4">
+        {recommended.length > 0 && (
+          <div className="text-xs font-semibold text-slate-400 uppercase tracking-wide">More kits</div>
+        )}
+        <div className="space-y-4">
+          {others.map((template) => renderTemplateCard(template, false))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default ProjectTemplatePicker;

--- a/code/types.ts
+++ b/code/types.ts
@@ -156,11 +156,30 @@ export interface Achievement {
     isUnlocked: (artifacts: Artifact[], projects: Project[]) => boolean;
 }
 
+export interface TemplateArtifactBlueprint {
+    title: string;
+    type: ArtifactType;
+    summary: string;
+    status?: string;
+    tags?: string[];
+    data?: Artifact['data'];
+}
+
+export interface ProjectTemplate {
+    id: string;
+    name: string;
+    description: string;
+    recommendedFor?: string[];
+    projectTags: string[];
+    artifacts: TemplateArtifactBlueprint[];
+}
+
 export interface TemplateEntry {
     id: string;
     name: string;
     description: string;
     tags?: string[];
+    blueprint?: TemplateArtifactBlueprint;
 }
 
 export interface TemplateCategory {


### PR DESCRIPTION
## Summary
- add a curated project template picker with starter artifacts for comics, conlangs, game design, and world wikis
- wire template application into the dashboard so projects gain default artifacts, tags, and XP when hydrated
- extend shared types for template blueprints and mark the roadmap item complete

## Testing
- npm run build *(fails: npm: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_6900e57e51a08328b0fd91ae6da763be