### PR TITLE
Add reusable project template kits

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A playful, gamified personal knowledge system for organizing web comics, wikis, 
 ### Phase 1 — Seed the Universe (Weeks 0‑4)
 - [ ] Deliver the Layer 1 capture flow: quick-create cards for ideas, characters, scenes, mechanics, and lexemes with inline tagging and lightweight linking.
 - [x] Move the XP/progression surface into a compact widget beside the creator portrait and collapse the full preferences + XP pane by default.
-- [ ] Add reusable project templates (comic, conlang, game design, wiki) that hydrate dashboards, tables, and starter artifacts.
+- [x] Add reusable project templates (comic, conlang, game design, wiki) that hydrate dashboards, tables, and starter artifacts.
 - [ ] Ensure changing projects resets AI-generated draft release notes so context stays accurate.
 
 ### Phase 2 — Grow Projects (Weeks 5‑8)

--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useMemo, useCallback, useRef, KeyboardEvent, useEffect } from 'react';
-import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, TaskData, TaskState, TemplateCategory, Milestone, AIAssistant, UserProfile } from './types';
+import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, TaskData, TaskState, TemplateCategory, Milestone, AIAssistant, UserProfile, Scene, TemplateSeed } from './types';
 import { CubeIcon, BookOpenIcon, PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon, SparklesIcon } from './components/Icons';
 import Modal from './components/Modal';
 import CreateArtifactForm from './components/CreateArtifactForm';
@@ -42,12 +42,105 @@ const achievements: Achievement[] = [
     { id: 'ach-4', title: 'Connector', description: 'Link 3 artifacts together.', isUnlocked: (artifacts) => artifacts.reduce((acc, a) => acc + a.relations.length, 0) >= 3 },
 ];
 
+const createDefaultDataForType = (type: ArtifactType, title: string): Artifact['data'] => {
+    switch (type) {
+        case ArtifactType.Conlang:
+            return [];
+        case ArtifactType.Story:
+            return [];
+        case ArtifactType.Task:
+            return { state: TaskState.Todo };
+        case ArtifactType.Character:
+            return { bio: '', traits: [] };
+        case ArtifactType.Wiki:
+            return { content: `# ${title}\n\n` };
+        case ArtifactType.Location:
+            return { description: '', features: [] };
+        default:
+            return {};
+    }
+};
+
+const composeSeedData = (seed: TemplateSeed): Artifact['data'] => {
+    if (seed.data === undefined) {
+        return createDefaultDataForType(seed.type, seed.title);
+    }
+
+    const base = createDefaultDataForType(seed.type, seed.title);
+
+    if (Array.isArray(seed.data)) {
+        return seed.data;
+    }
+
+    if (Array.isArray(base)) {
+        return seed.data;
+    }
+
+    if (typeof base === 'object' && typeof seed.data === 'object') {
+        return {
+            ...(base as Record<string, unknown>),
+            ...(seed.data as Record<string, unknown>),
+        };
+    }
+
+    return seed.data;
+};
+
 const templateLibrary: TemplateCategory[] = [
     {
         id: 'tamenzut',
         title: 'Tamenzut Series',
         description: 'High-fantasy seeds that keep the Tamenzut saga consistent from novel to novel.',
         recommendedFor: ['Tamenzut'],
+        dashboardHints: ['Table: Lore sweeps', 'Graph: Faction webs', 'Kanban: Ritual prep'],
+        starterArtifacts: [
+            {
+                title: 'Threadweaving Laws',
+                type: ArtifactType.MagicSystem,
+                summary: 'Codify the core tenets, prices, and taboos of the saga’s magic.',
+                status: 'draft',
+                tags: ['magic', 'canon'],
+                data: {
+                    tenets: ['Emotion anchors any weave.', 'Balance of twin moons limits potency.'],
+                    costs: ['Silvering veins after overuse.', 'Shared pain with bonded casters.'],
+                    taboos: ['Never weave across royal bloodlines.', 'No reviving the twice-fallen.'],
+                },
+            },
+            {
+                title: 'Edruel Ruin Mystery',
+                type: ArtifactType.Story,
+                summary: 'Scene skeleton following the ancient ruin’s discovery and fallout.',
+                status: 'outline',
+                tags: ['plot', 'mystery'],
+                data: [
+                    { id: 'scene-edruel-1', title: 'Inciting Discovery', summary: 'Archaeologists unearth a moon-bound sigil at the ruin’s heart.' },
+                    { id: 'scene-edruel-2', title: 'Council Fractures', summary: 'Factions argue over whether to unlock the sigil.' },
+                    { id: 'scene-edruel-3', title: 'Moonfall Choice', summary: 'Threadweavers must decide between sealing or wielding the power.' },
+                ] as Scene[],
+            },
+            {
+                title: 'Treaty Summit Agenda',
+                type: ArtifactType.Task,
+                summary: 'Prep talking points before the three guilds arrive at the citadel.',
+                status: 'todo',
+                tags: ['diplomacy', 'priority'],
+                data: { state: TaskState.InProgress, assignee: 'Lore Council', due: '2024-10-01' },
+            },
+            {
+                title: 'Gilded City Atlas',
+                type: ArtifactType.Location,
+                summary: 'District notes for the capital’s markets, sanctums, and underways.',
+                status: 'draft',
+                tags: ['location'],
+                data: {
+                    description: 'A sun-drenched metropolis of sandstone towers, mirrored canals, and shadowed tunnels beneath.',
+                    features: [
+                        { id: 'feature-gilded-market', name: 'Sunstone Market', description: 'Bazaar where moon-silver and thread reagents trade hands at dawn.' },
+                        { id: 'feature-gilded-sanctum', name: 'Auric Sanctum', description: 'Temple storing relic vows and elemental anchors.' },
+                    ],
+                },
+            },
+        ],
         templates: [
             { id: 'tam-magic-system', name: 'MagicSystem', description: 'Document the laws, costs, and taboos of threadweaving.', tags: ['magic', 'systems'] },
             { id: 'tam-rulebook', name: 'Rulebook', description: 'Capture canon rulings, rituals, and battle procedures.', tags: ['canon', 'reference'] },
@@ -63,6 +156,53 @@ const templateLibrary: TemplateCategory[] = [
         title: 'Steamweave / Anya',
         description: 'Coal-punk ops boards for Anya’s guild drama and gadgeteering.',
         recommendedFor: ['Steamweave'],
+        dashboardHints: ['Storyboard: Episode arcs', 'Kanban: Gadget backlog'],
+        starterArtifacts: [
+            {
+                title: 'Coalheart Confrontation',
+                type: ArtifactType.Story,
+                summary: 'Storyboard the rooftop clash against the Red-Eyes enforcers.',
+                status: 'outline',
+                tags: ['action', 'episode'],
+                data: [
+                    { id: 'scene-coalheart-1', title: 'Gearlift Ambush', summary: 'Anya and crew hijack a freight lift mid-ascent.' },
+                    { id: 'scene-coalheart-2', title: 'Sparkstorm', summary: 'Prototype coils overload, threatening the city grid.' },
+                    { id: 'scene-coalheart-3', title: 'Skyline Escape', summary: 'Final panel of the crew leaping across airship tethers.' },
+                ] as Scene[],
+            },
+            {
+                title: 'Anya’s Workshop Manual',
+                type: ArtifactType.Wiki,
+                summary: 'Living doc covering stations, rituals, and emergency drills.',
+                status: 'draft',
+                tags: ['operations'],
+                data: {
+                    content: '# Workshop Protocols\n\n- **Stations:** Coil Forge, Tether Lab, Signal Loft.\n- **Shift Ritual:** Begin with a shared story scrap to align mood.\n- **Failsafe:** Pull the brass raven to vent pressure into the tower spire.',
+                },
+            },
+            {
+                title: 'Panel Sprint Backlog',
+                type: ArtifactType.Task,
+                summary: 'Track the next issue’s key beats and art chores in one place.',
+                status: 'in-progress',
+                tags: ['storyboard', 'production'],
+                data: { state: TaskState.InProgress, assignee: 'Art Guild', due: '2024-08-15' },
+            },
+            {
+                title: 'Guild Operatives Roster',
+                type: ArtifactType.Character,
+                summary: 'Snapshot bios for the current crew and their unique gimmicks.',
+                status: 'draft',
+                tags: ['team'],
+                data: {
+                    bio: 'Operatives recruited from rival guilds, each with a signature gadget and emotional hook.',
+                    traits: [
+                        { id: 'trait-anya', key: 'Specialty', value: 'Coil harmonics & risk calculus' },
+                        { id: 'trait-marlow', key: 'Tell', value: 'Rewinds watch spring when lying' },
+                    ],
+                },
+            },
+        ],
         templates: [
             { id: 'steam-clan', name: 'Clan', description: 'Roster clan leadership, ranks, and rivalries.', tags: ['faction'] },
             { id: 'steam-workshop', name: 'Workshop', description: 'Layout stations, ongoing inventions, and supply flows.', tags: ['location', 'operations'] },
@@ -77,6 +217,53 @@ const templateLibrary: TemplateCategory[] = [
         title: 'Dustland RPG',
         description: 'Questline scaffolds for the Dustland tabletop campaign.',
         recommendedFor: ['Dustland'],
+        dashboardHints: ['Table: Module tracker', 'Kanban: Playtest loops', 'Graph: Encounter chain'],
+        starterArtifacts: [
+            {
+                title: 'Ashfall Module Blueprint',
+                type: ArtifactType.Game,
+                summary: 'Campaign skeleton with core loop, pillars, and escalation plan.',
+                status: 'draft',
+                tags: ['module'],
+                data: {
+                    coreLoop: ['Briefing at Dustmarket', 'Scavenge the ash zones', 'Retreat to repair caravans'],
+                    pillars: ['Exploration', 'Resource Tension', 'Faction Reputation'],
+                    escalation: 'Introduce volcanic storms that force players into hostile alliances.',
+                },
+            },
+            {
+                title: 'Playtest Wave One',
+                type: ArtifactType.Task,
+                summary: 'Schedule and capture feedback from the first Dustland playtest.',
+                status: 'in-progress',
+                tags: ['playtest'],
+                data: { state: TaskState.InProgress, assignee: 'GM Team', due: '2024-07-20' },
+            },
+            {
+                title: 'Dustmarket Bazaar',
+                type: ArtifactType.Location,
+                summary: 'Encounter map plus standout vendors for the caravan hub.',
+                status: 'draft',
+                tags: ['map'],
+                data: {
+                    description: 'A shanty town of welded hulls and fabric awnings, trading scrap miracles and whispered quests.',
+                    features: [
+                        { id: 'feature-bazaar-auction', name: 'Soot Auction Deck', description: 'Weekly gambles for rare scavenged tech.' },
+                        { id: 'feature-bazaar-canteen', name: 'Cinder Canteen', description: 'Neutral ground for rumor trading and faction side deals.' },
+                    ],
+                },
+            },
+            {
+                title: 'Rule Variants Ledger',
+                type: ArtifactType.Wiki,
+                summary: 'Document optional rules for grit damage, convoy upgrades, and weather.',
+                status: 'draft',
+                tags: ['rules'],
+                data: {
+                    content: '# Rule Variants\n\n## Grit Damage\nTrack cumulative stress; spend 3 grit for heroic last stands.\n\n## Convoy Upgrades\nUnlock tiered rigs that modify caravan travel dice.\n\n## Weather Fronts\nEach storm adds environmental tags to encounters.',
+                },
+            },
+        ],
         templates: [
             { id: 'dust-module', name: 'Module', description: 'Outline module scope, level bands, and key beats.', tags: ['campaign'] },
             { id: 'dust-quest', name: 'Quest', description: 'Track objectives, rewards, and branching outcomes.', tags: ['quest'] },
@@ -92,6 +279,53 @@ const templateLibrary: TemplateCategory[] = [
         title: 'Spatch League',
         description: 'Sports-drama templates tuned for the Spatch comic universe.',
         recommendedFor: ['Spatch'],
+        dashboardHints: ['Storyboard: Match pacing', 'Kanban: Training arcs'],
+        starterArtifacts: [
+            {
+                title: 'Season Opener Match Board',
+                type: ArtifactType.Story,
+                summary: 'Panel beats for the rivalry opener at the sky rink.',
+                status: 'outline',
+                tags: ['match', 'storyboard'],
+                data: [
+                    { id: 'scene-spatch-1', title: 'Opening Rally', summary: 'Crowd chant surges as the Spatch crew enters under floodlights.' },
+                    { id: 'scene-spatch-2', title: 'Mid-game Twist', summary: 'New rule variant triggers a double-ball sequence.' },
+                    { id: 'scene-spatch-3', title: 'Final Panel', summary: 'Protagonist lands an impossible spike, setting up a cliffhanger.' },
+                ] as Scene[],
+            },
+            {
+                title: 'Coach Mila Dossier',
+                type: ArtifactType.Character,
+                summary: 'Character sheet for the team’s strategist mentor.',
+                status: 'draft',
+                tags: ['mentor'],
+                data: {
+                    bio: 'Former league champion coaching the underdog Spatch squad with tactical riddles.',
+                    traits: [
+                        { id: 'trait-mila-style', key: 'Coaching Style', value: 'Puzzle-centric drills' },
+                        { id: 'trait-mila-secret', key: 'Secret', value: 'Hiding a career-ending injury relapse' },
+                    ],
+                },
+            },
+            {
+                title: 'Training Montage Checklist',
+                type: ArtifactType.Task,
+                summary: 'Track beats for the team’s leveling-up montage.',
+                status: 'todo',
+                tags: ['training'],
+                data: { state: TaskState.Todo, assignee: 'Captain Iro', due: '2024-06-30' },
+            },
+            {
+                title: 'Broadcast Notes',
+                type: ArtifactType.Wiki,
+                summary: 'Flavor commentary, catchphrases, and sponsor beats.',
+                status: 'draft',
+                tags: ['presentation'],
+                data: {
+                    content: '# Broadcast Notes\n\n- Signature call: "Spatch that spark!"\n- Sideline reporter: Lani Quill.\n- Sponsor slots: GlideTech Boards, Nebula Noodles.',
+                },
+            },
+        ],
         templates: [
             { id: 'spatch-team', name: 'Team', description: 'Roster starters, strategies, and rival teams.', tags: ['team'] },
             { id: 'spatch-mentor', name: 'Mentor', description: 'Capture training montages, philosophies, and signature drills.', tags: ['character'] },
@@ -105,6 +339,50 @@ const templateLibrary: TemplateCategory[] = [
         title: 'Darv Conlang',
         description: 'Linguistic workbench for the ancient language of the Darv.',
         recommendedFor: ['Darv'],
+        dashboardHints: ['Table: Lexicon expansions', 'Kanban: Paradigm backlog'],
+        starterArtifacts: [
+            {
+                title: 'Darv Lexicon Core',
+                type: ArtifactType.Conlang,
+                summary: 'Seed set of lexemes anchoring dialect contrasts.',
+                status: 'draft',
+                tags: ['lexicon'],
+                data: [
+                    { id: 'lex-darv-1', lemma: 'sael', pos: 'n', gloss: 'emberlight', etymology: 'Proto-Darv *sa', tags: ['elemental'] },
+                    { id: 'lex-darv-2', lemma: 'veruun', pos: 'v', gloss: 'to braid souls', etymology: 'Loan from temple cant', tags: ['ritual'] },
+                    { id: 'lex-darv-3', lemma: 'ithren', pos: 'adj', gloss: 'echoing, resounding', tags: ['poetic'] },
+                ] as ConlangLexeme[],
+            },
+            {
+                title: 'Phonology Overview',
+                type: ArtifactType.Wiki,
+                summary: 'Consonant clusters, vowel harmony, and stress notes.',
+                status: 'draft',
+                tags: ['phonology'],
+                data: {
+                    content: '# Phonology\n\n- Consonant clusters favor liquid + fricative.\n- Vowels shift front/back to mark tense.\n- Primary stress on penultimate syllable unless marked by grave accent.',
+                },
+            },
+            {
+                title: 'Paradigm Sprint',
+                type: ArtifactType.Task,
+                summary: 'Draft noun cases for animate vs. inanimate groups.',
+                status: 'todo',
+                tags: ['grammar'],
+                data: { state: TaskState.Todo, assignee: 'Conlang Smith', due: '2024-07-05' },
+            },
+            {
+                title: 'Cultural Proverbs',
+                type: ArtifactType.Story,
+                summary: 'Short proverb collection with translation notes.',
+                status: 'draft',
+                tags: ['culture'],
+                data: [
+                    { id: 'scene-darv-1', title: 'Stormglass Lesson', summary: '“Sael tvar ithren” — light only answers the patient bell.' },
+                    { id: 'scene-darv-2', title: 'River Bargain', summary: '“Veluun etha” — promises braid tighter than rope.' },
+                ] as Scene[],
+            },
+        ],
         templates: [
             { id: 'darv-lexicon', name: 'Lexicon', description: 'List lemmas, glosses, and phonological notes.', tags: ['language'] },
             { id: 'darv-phonology', name: 'Phonology', description: 'Summarize phonemes, clusters, and stress rules.', tags: ['language'] },
@@ -118,6 +396,55 @@ const templateLibrary: TemplateCategory[] = [
         title: 'Sacred Truth Dossiers',
         description: 'Supernatural investigation kits for the Sacred Truth vampire saga.',
         recommendedFor: ['Sacred Truth'],
+        dashboardHints: ['Table: Case files', 'Kanban: Field ops', 'Graph: Monster ties'],
+        starterArtifacts: [
+            {
+                title: 'Case File: Eclipse Choir',
+                type: ArtifactType.Wiki,
+                summary: 'Primary investigation board tracking the cult targeting night markets.',
+                status: 'draft',
+                tags: ['case-file'],
+                data: {
+                    content: '# Case File: Eclipse Choir\n\n**Summary:** Choir siphons aura from market-goers to awaken a dormant archbishop.\n\n**Suspects:**\n- Maestro Veyl — charismatic conductor\n- Sister Lume — reliquary keeper\n\n**Open Leads:**\n1. Decode hymn cipher.\n2. Stakeout cathedral catacombs.',
+                },
+            },
+            {
+                title: 'Field Ops: Cathedral Sweep',
+                type: ArtifactType.Task,
+                summary: 'Coordinate strike teams before the eclipse ritual begins.',
+                status: 'todo',
+                tags: ['ops'],
+                data: { state: TaskState.Todo, assignee: 'Night Brigade', due: '2024-05-30' },
+            },
+            {
+                title: 'Monster Codex: Blood Scribes',
+                type: ArtifactType.Character,
+                summary: 'Profile of the vampiric historians bound to cathedral vaults.',
+                status: 'draft',
+                tags: ['bestiary'],
+                data: {
+                    bio: 'Blood Scribes transcribe living memories using sanguine ink, trading secrets for protection.',
+                    traits: [
+                        { id: 'trait-scribe-ink', key: 'Tell', value: 'Eyes glow ruby when recalling forbidden lore' },
+                        { id: 'trait-scribe-weakness', key: 'Weakness', value: 'Cannot cross running water carrying ink' },
+                    ],
+                },
+            },
+            {
+                title: 'Cathedral Vault Map',
+                type: ArtifactType.Location,
+                summary: 'Annotated layout of reliquary chambers and hidden escape shafts.',
+                status: 'draft',
+                tags: ['map'],
+                data: {
+                    description: 'Labyrinth of marble cloisters, reliquary pits, and shadow wells beneath the cathedral.',
+                    features: [
+                        { id: 'feature-vault-choir', name: 'Chorus Pit', description: 'Acoustic chamber where hymns amplify blood rites.' },
+                        { id: 'feature-vault-escape', name: 'Echo Passage', description: 'Secret tunnel leading to the city aqueduct.' },
+                    ],
+                },
+            },
+        ],
         templates: [
             { id: 'sacred-episode', name: 'Episode', description: 'Structure case-of-the-week arcs with cold opens and cliffhangers.', tags: ['story'] },
             { id: 'sacred-case', name: 'Case File', description: 'Log evidence, suspects, and unresolved leads.', tags: ['mystery'] },
@@ -412,13 +739,7 @@ export default function App() {
   const handleCreateArtifact = useCallback(({ title, type, summary }: { title: string; type: ArtifactType; summary: string }) => {
     if (!selectedProjectId || !profile) return;
 
-    let data: Artifact['data'] = {};
-    if (type === ArtifactType.Conlang) data = [];
-    if (type === ArtifactType.Story) data = [];
-    if (type === ArtifactType.Task) data = { state: TaskState.Todo };
-    if (type === ArtifactType.Character) data = { bio: '', traits: [] };
-    if (type === ArtifactType.Wiki) data = { content: `# ${title}\n\n` };
-    if (type === ArtifactType.Location) data = { description: '', features: [] };
+    const data = createDefaultDataForType(type, title);
 
     const newArtifact: Artifact = {
       id: `art-${Date.now()}`,
@@ -438,6 +759,82 @@ export default function App() {
     setIsCreateModalOpen(false);
     setSelectedArtifactId(newArtifact.id);
   }, [profile, selectedProjectId, addXp, setArtifacts]);
+
+  const handleApplyTemplateKit = useCallback((category: TemplateCategory) => {
+    if (!selectedProjectId || !profile) {
+      return {
+        createdCount: 0,
+        skippedCount: category.starterArtifacts.length,
+        message: 'Select a project to apply a template kit.',
+      };
+    }
+
+    const existingTitles = new Map<string, string>();
+    projectArtifacts.forEach((artifact) => {
+      existingTitles.set(artifact.title.toLowerCase(), artifact.id);
+    });
+
+    const timestamp = Date.now();
+    let created = 0;
+    const newArtifacts: Artifact[] = [];
+
+    category.starterArtifacts.forEach((seed, index) => {
+      const normalizedTitle = seed.title.toLowerCase();
+      if (existingTitles.has(normalizedTitle)) {
+        return;
+      }
+
+      const artifactData = composeSeedData(seed);
+      const artifactId = `art-${timestamp}-${index}`;
+      const artifact: Artifact = {
+        id: artifactId,
+        ownerId: profile.uid,
+        projectId: selectedProjectId,
+        type: seed.type,
+        title: seed.title,
+        summary: seed.summary,
+        status: seed.status ?? 'idea',
+        tags: seed.tags ?? [],
+        relations: [],
+        data: artifactData,
+      };
+
+      newArtifacts.push(artifact);
+      existingTitles.set(normalizedTitle, artifactId);
+      created += 1;
+    });
+
+    if (newArtifacts.length > 0) {
+      setArtifacts((prev) => [...prev, ...newArtifacts]);
+      addXp(newArtifacts.length * 4);
+      setSelectedArtifactId(newArtifacts[0].id);
+      const kitTag = `kit:${category.id}`;
+      setProjects((prev) => prev.map((project) => {
+        if (project.id !== selectedProjectId) return project;
+        return project.tags.includes(kitTag)
+          ? project
+          : { ...project, tags: [...project.tags, kitTag] };
+      }));
+    }
+
+    const skipped = category.starterArtifacts.length - created;
+    const messageParts: string[] = [];
+    if (created > 0) {
+      messageParts.push(`Added ${created} starter artifact${created === 1 ? '' : 's'}.`);
+    }
+    if (skipped > 0) {
+      messageParts.push(`${skipped} already existed in this project.`);
+    }
+    if (messageParts.length === 0) {
+      messageParts.push('All kit artifacts already exist in this project.');
+    }
+
+    return {
+      createdCount: created,
+      skippedCount: skipped,
+      message: messageParts.join(' '),
+    };
+  }, [selectedProjectId, profile, projectArtifacts, setArtifacts, addXp, setSelectedArtifactId, setProjects]);
 
   const handleImportClick = () => {
     fileInputRef.current?.click();
@@ -771,7 +1168,12 @@ export default function App() {
                 </div>
               )}
               <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 mt-8">
-                <TemplateGallery categories={templateLibrary} activeProjectTitle={selectedProject.title} />
+                <TemplateGallery
+                    categories={templateLibrary}
+                    activeProjectTitle={selectedProject.title}
+                    onApplyTemplate={handleApplyTemplateKit}
+                    canApply={Boolean(selectedProjectId)}
+                />
                 <ReleaseNotesGenerator
                     projectTitle={selectedProject.title}
                     artifacts={projectArtifacts}

--- a/code/types.ts
+++ b/code/types.ts
@@ -163,12 +163,29 @@ export interface TemplateEntry {
     tags?: string[];
 }
 
+export interface TemplateSeedRelation {
+    toTitle: string;
+    kind: string;
+}
+
+export interface TemplateSeed {
+    title: string;
+    type: ArtifactType;
+    summary: string;
+    status?: string;
+    tags?: string[];
+    data?: Artifact['data'];
+    relations?: TemplateSeedRelation[];
+}
+
 export interface TemplateCategory {
     id: string;
     title: string;
     description: string;
     recommendedFor: string[];
     templates: TemplateEntry[];
+    starterArtifacts: TemplateSeed[];
+    dashboardHints?: string[];
 }
 
 export interface Milestone {


### PR DESCRIPTION
## Summary
- add dashboard hints and starter artifacts to each template kit category
- enable TemplateGallery to apply template kits and provide feedback in the UI
- hydrate projects by creating default artifacts when a kit is applied and track applied kits on the project

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900e57e51a08328b0fd91ae6da763be