### PR TITLE
Refactor App type imports to reduce merge conflicts

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1,6 +1,22 @@
 
 import React, { useState, useMemo, useCallback, useRef, KeyboardEvent, useEffect } from 'react';
-import { Project, Artifact, ProjectStatus, ArtifactType, ConlangLexeme, Quest, Relation, Achievement, TaskData, TaskState, TemplateCategory, Milestone, AIAssistant, UserProfile, ProjectTemplate } from './types';
+import {
+    AIAssistant,
+    Achievement,
+    Artifact,
+    ArtifactType,
+    ConlangLexeme,
+    Milestone,
+    Project,
+    ProjectStatus,
+    ProjectTemplate,
+    Quest,
+    Relation,
+    TaskData,
+    TaskState,
+    TemplateCategory,
+    UserProfile,
+} from './types';
 import { CubeIcon, BookOpenIcon, PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon, SparklesIcon } from './components/Icons';
 import Modal from './components/Modal';
 import CreateArtifactForm from './components/CreateArtifactForm';


### PR DESCRIPTION
## Summary
- format the type import block in `code/App.tsx` across multiple lines so identifiers stay ordered and reduce merge conflicts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900e83a8abc83289899fa06aada6918