### PR TITLE
Clarify template surfaces copy and badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A playful, gamified personal knowledge system for organizing web comics, wikis, 
 - [ ] Deliver the Layer 1 capture flow: quick-create cards for ideas, characters, scenes, mechanics, and lexemes with inline tagging and lightweight linking.
 - [x] Move the XP/progression surface into a compact widget beside the creator portrait and collapse the full preferences + XP pane by default.
 - [x] Add reusable project templates (comic, conlang, game design, wiki) that hydrate dashboards, tables, and starter artifacts.
-- [ ] Clarify the copy and badges that differentiate "Project Templates" (multi-artifact kits) from the exploratory "Template Library" surface.
+- [x] Clarify the copy and badges that differentiate "Project Templates" (multi-artifact kits) from the exploratory "Template Library" surface.
 - [ ] Link each project template to the underlying template-library categories (and vice versa) so the hierarchy is obvious while keeping both entry points.
 - [ ] Ensure changing projects resets AI-generated draft release notes so context stays accurate.
 

--- a/code/components/ProjectTemplatePicker.tsx
+++ b/code/components/ProjectTemplatePicker.tsx
@@ -84,13 +84,21 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
 
   return (
     <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
-      <header className="space-y-2">
-        <div className="flex items-center gap-2 text-sm font-semibold text-slate-300 uppercase tracking-wide">
-          <SparklesIcon className="w-5 h-5 text-cyan-400" />
-          Project Templates
+      <header className="space-y-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-slate-300 uppercase tracking-wide">
+            <SparklesIcon className="w-5 h-5 text-cyan-400" />
+            Project Templates
+          </div>
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-cyan-200 bg-cyan-900/40 border border-cyan-700/50 rounded-full px-3 py-1">
+            Multi-artifact kit
+          </span>
         </div>
         <p className="text-sm text-slate-400">
-          Drop in curated starter artifacts to hydrate dashboards instantly. Existing entries are preserved—new templates only add what&apos;s missing.
+          Hydrate an entire project with dashboards, quests, and starter artifacts in one click. Apply a kit to fill gaps without overwriting the custom work you have already done.
+        </p>
+        <p className="text-xs text-slate-500">
+          Looking for single artifacts to mix and match? Browse the Template Library next door.
         </p>
       </header>
 

--- a/code/components/TemplateGallery.tsx
+++ b/code/components/TemplateGallery.tsx
@@ -88,13 +88,20 @@ const TemplateGallery: React.FC<TemplateGalleryProps> = ({ categories, activePro
   return (
     <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
       <header className="flex flex-col gap-3">
-        <div className="flex items-center gap-2 text-sm font-semibold text-slate-300 uppercase tracking-wide">
-          <SparklesIcon className="w-5 h-5 text-cyan-400" />
-          Template Library
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-2 text-sm font-semibold text-slate-300 uppercase tracking-wide">
+            <SparklesIcon className="w-5 h-5 text-cyan-400" />
+            Template Library
+          </div>
+          <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-200 bg-amber-900/30 border border-amber-700/50 rounded-full px-3 py-1">
+            Artifact blueprints
+          </span>
         </div>
         <p className="text-sm text-slate-400">
-          Jump-start new artifacts with ready-made scaffolds tuned for recurring universes and genres. Search or pick from the
-          curated sets below.
+          Drop in single artifacts to expand a project a la carte. Each blueprint mirrors the categories above but won&apos;t touch dashboards or quests.
+        </p>
+        <p className="text-xs text-slate-500">
+          Want a whole world scaffolded at once? Use the Project Templates kits before dipping into the library.
         </p>
         <div className="relative">
           <MagnifyingGlassIcon className="w-4 h-4 text-slate-500 absolute left-3 top-1/2 -translate-y-1/2" />


### PR DESCRIPTION
## Summary
- add explicit badges and descriptions that position project templates as multi-artifact kits
- highlight the template library as artifact-level blueprints with copy guiding when to use each surface
- mark the roadmap item for clarifying copy and badges as complete

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900ec7762e08328bfa664d90443b98d