### PR TITLE
Implement template kit hydration flow

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -14,6 +14,7 @@ import {
     Relation,
     TaskData,
     TaskState,
+    TemplateApplicationSummary,
     TemplateCategory,
     UserProfile,
 } from './types';
@@ -45,6 +46,8 @@ import { useAuth } from './contexts/AuthContext';
 import UserProfileCard from './components/UserProfileCard';
 import GitHubImportPanel from './components/GitHubImportPanel';
 import SecondaryInsightsPanel from './components/SecondaryInsightsPanel';
+import { getDefaultDataForType } from './utils/artifactDefaults';
+import { buildTemplateSummary, hydrateTemplate } from './utils/templateHydrator';
 
 const dailyQuests: Quest[] = [
     { id: 'q1', title: 'First Seed', description: 'Create at least one new artifact.', isCompleted: (artifacts) => artifacts.length > 7, xp: 5 },
@@ -158,28 +161,44 @@ const projectTemplates: ProjectTemplate[] = [
         recommendedFor: ['Spatch', 'Steamweave'],
         relatedCategoryIds: ['steamweave', 'spatch'],
         projectTags: ['comic', 'storyboard', 'production'],
+        xpReward: 20,
+        artifactXpReward: 6,
+        dashboardHints: [
+            'Pin the season roadmap to spotlight upcoming beats on the control panel.',
+            'Surface the sprint backlog widget to keep lettering and marketing in view.',
+        ],
         artifacts: [
             {
+                blueprintId: 'season-roadmap',
                 title: 'Season Roadmap',
                 type: ArtifactType.Story,
-                summary: 'Outline upcoming arcs, spotlight issues, and publishing cadence.',
+                summary: 'Outline upcoming arcs for {{project}}, spotlight issues, and publishing cadence.',
                 status: 'draft',
                 tags: ['roadmap', 'issues'],
+                xpReward: 8,
             },
             {
+                blueprintId: 'cast-gallery',
                 title: 'Cast Gallery',
                 type: ArtifactType.Character,
                 summary: 'Snapshot bios, motivations, and relationship notes for the main cast.',
                 status: 'idea',
                 tags: ['characters', 'reference'],
+                relations: [
+                    { toBlueprintId: 'season-roadmap', kind: 'INFORMS' },
+                ],
             },
             {
+                blueprintId: 'issue-sprint',
                 title: 'Issue Sprint Backlog',
                 type: ArtifactType.Task,
                 summary: 'Track page breakdowns, lettering, and marketing beats for the next drop.',
                 status: 'in-progress',
                 tags: ['sprint', 'release'],
                 data: { state: TaskState.InProgress } as TaskData,
+                relations: [
+                    { toBlueprintId: 'season-roadmap', kind: 'TRACKS' },
+                ],
             },
         ],
     },
@@ -190,8 +209,15 @@ const projectTemplates: ProjectTemplate[] = [
         recommendedFor: ['Tamenzut', 'Darv'],
         relatedCategoryIds: ['tamenzut', 'darv'],
         projectTags: ['conlang', 'language'],
+        xpReward: 18,
+        artifactXpReward: 5,
+        dashboardHints: [
+            'Embed the lexicon table on the dashboard to surface recent additions.',
+            'Track phonology todos alongside wiki callouts for quick reference.',
+        ],
         artifacts: [
             {
+                blueprintId: 'lexicon-seed',
                 title: 'Lexicon Seed',
                 type: ArtifactType.Conlang,
                 summary: 'Kick off vocabulary batches with phonotactics and thematic tags.',
@@ -201,21 +227,32 @@ const projectTemplates: ProjectTemplate[] = [
                     { id: 'tmpl-lex-1', lemma: 'salar', pos: 'n', gloss: 'ember-forged song' },
                     { id: 'tmpl-lex-2', lemma: 'vith', pos: 'adj', gloss: 'woven with starlight' },
                 ] as ConlangLexeme[],
+                xpReward: 6,
             },
             {
+                blueprintId: 'grammar-notes',
                 title: 'Grammar Notes',
                 type: ArtifactType.Wiki,
-                summary: 'Document morphology, syntax quirks, and inspiration languages.',
+                summary: 'Document morphology, syntax quirks, and inspiration languages for {{project}}.',
                 status: 'idea',
                 tags: ['reference'],
                 data: { content: '## Phonology\n- Consonant harmony sketch\n\n## Morphology\n- Case markers TBD' },
+                relations: [
+                    { toBlueprintId: 'lexicon-seed', kind: 'CITES' },
+                ],
             },
             {
+                blueprintId: 'phonology-sprint',
                 title: 'Phonology Recording Sprint',
                 type: ArtifactType.Task,
                 summary: 'Capture sound samples and finalize the consonant inventory.',
                 status: 'todo',
                 tags: ['audio', 'phonology'],
+                data: { state: TaskState.Todo } as TaskData,
+                relations: [
+                    { toBlueprintId: 'lexicon-seed', kind: 'TRACKS' },
+                    { toBlueprintId: 'grammar-notes', kind: 'BLOCKED_BY' },
+                ],
             },
         ],
     },
@@ -226,8 +263,15 @@ const projectTemplates: ProjectTemplate[] = [
         recommendedFor: ['Dustland'],
         relatedCategoryIds: ['dustland'],
         projectTags: ['game', 'systems'],
+        xpReward: 24,
+        artifactXpReward: 6,
+        dashboardHints: [
+            'Feature the core loop dashboard tile to align the team on moment-to-moment play.',
+            'Pin the playtest backlog next to the milestone tracker for quick triage.',
+        ],
         artifacts: [
             {
+                blueprintId: 'core-loop',
                 title: 'Core Loop Prototype',
                 type: ArtifactType.Game,
                 summary: 'Define what players do minute-to-minute and the rewards that fuel repeat sessions.',
@@ -235,27 +279,39 @@ const projectTemplates: ProjectTemplate[] = [
                 tags: ['core-loop', 'prototype'],
             },
             {
+                blueprintId: 'mechanics-glossary',
                 title: 'Mechanics Glossary',
                 type: ArtifactType.MagicSystem,
                 summary: 'Catalog resources, ability cooldowns, and failure states.',
                 status: 'idea',
                 tags: ['mechanics'],
+                relations: [
+                    { toBlueprintId: 'core-loop', kind: 'SUPPORTS' },
+                ],
             },
             {
+                blueprintId: 'playtest-backlog',
                 title: 'Playtest Feedback Backlog',
                 type: ArtifactType.Task,
                 summary: 'Triage insights from the latest playtest into actionable follow-ups.',
                 status: 'in-progress',
                 tags: ['playtest'],
                 data: { state: TaskState.InProgress } as TaskData,
+                relations: [
+                    { toBlueprintId: 'core-loop', kind: 'VALIDATES' },
+                ],
             },
             {
+                blueprintId: 'design-log',
                 title: 'Design Log',
                 type: ArtifactType.Wiki,
                 summary: 'Chronicle key decisions, questions, and experiments.',
                 status: 'draft',
                 tags: ['journal'],
                 data: { content: '## Decisions\n- Note major pivots here\n\n## Open Questions\n- Capture follow-ups from playtests' },
+                relations: [
+                    { toBlueprintId: 'playtest-backlog', kind: 'SUMMARIZES' },
+                ],
             },
         ],
     },
@@ -266,16 +322,24 @@ const projectTemplates: ProjectTemplate[] = [
         recommendedFor: ['Tamenzut', 'Sacred Truth'],
         relatedCategoryIds: ['tamenzut', 'sacred-truth'],
         projectTags: ['wiki', 'lore'],
+        xpReward: 22,
+        artifactXpReward: 5,
+        dashboardHints: [
+            'Keep the encyclopedia pinned to quickly jump into canon edits.',
+            'Show the faction backlog on the dashboard to burn down lore debt.',
+        ],
         artifacts: [
             {
+                blueprintId: 'world-encyclopedia',
                 title: 'World Encyclopedia',
                 type: ArtifactType.Wiki,
-                summary: 'Master index for timelines, factions, and canon checkpoints.',
+                summary: 'Master index for timelines, factions, and canon checkpoints across {{project}}.',
                 status: 'draft',
                 tags: ['index'],
                 data: { content: '# World Encyclopedia\n\n## Overview\n- Establish tone and era\n\n## Canon Queue\n- Pending lore to verify' },
             },
             {
+                blueprintId: 'starting-region',
                 title: 'Starting Region Profile',
                 type: ArtifactType.Location,
                 summary: 'Describe the primary hub with landmarks, cultures, and conflicts.',
@@ -287,37 +351,26 @@ const projectTemplates: ProjectTemplate[] = [
                         { id: 'tmpl-feature-1', name: 'Beacon Market', description: 'Central plaza where rumors and quests surface.' },
                     ],
                 },
+                relations: [
+                    { toBlueprintId: 'world-encyclopedia', kind: 'FEATURED_IN' },
+                ],
             },
             {
+                blueprintId: 'faction-briefs',
                 title: 'Faction Briefs Backlog',
                 type: ArtifactType.Task,
                 summary: 'List the organizations you still need to document and their urgency.',
                 status: 'todo',
                 tags: ['factions', 'backlog'],
+                data: { state: TaskState.Todo } as TaskData,
+                relations: [
+                    { toBlueprintId: 'world-encyclopedia', kind: 'INFORMS' },
+                    { toBlueprintId: 'starting-region', kind: 'REFERENCES' },
+                ],
             },
         ],
     },
 ];
-
-const getDefaultDataForType = (type: ArtifactType, title?: string): Artifact['data'] => {
-    switch (type) {
-        case ArtifactType.Conlang:
-            return [];
-        case ArtifactType.Story:
-        case ArtifactType.Scene:
-            return [];
-        case ArtifactType.Task:
-            return { state: TaskState.Todo } as TaskData;
-        case ArtifactType.Character:
-            return { bio: '', traits: [] };
-        case ArtifactType.Wiki:
-            return { content: `# ${title ?? 'Untitled'}\n\n` };
-        case ArtifactType.Location:
-            return { description: '', features: [] };
-        default:
-            return {};
-    }
-};
 
 const milestoneRoadmap: Milestone[] = [
     {
@@ -638,35 +691,32 @@ export default function App() {
     setSelectedArtifactId(newArtifact.id);
   }, [profile, selectedProjectId, addXp, setArtifacts]);
 
-  const handleApplyProjectTemplate = useCallback((template: ProjectTemplate) => {
-    if (!profile || !selectedProjectId) return;
+  const handleApplyProjectTemplate = useCallback(async (template: ProjectTemplate): Promise<TemplateApplicationSummary> => {
+    if (!profile || !selectedProjectId || !selectedProject) {
+      return {
+        templateId: template.id,
+        createdTitles: [],
+        skippedTitles: [],
+        xpAwarded: 0,
+      };
+    }
 
     const projectArtifactsForSelection = artifacts.filter(artifact => artifact.projectId === selectedProjectId);
-    const existingTitles = new Set(projectArtifactsForSelection.map(artifact => artifact.title.toLowerCase()));
-    const timestamp = Date.now();
+    const outcome = hydrateTemplate({
+      template,
+      ownerId: profile.uid,
+      projectId: selectedProjectId,
+      projectTitle: selectedProject.title,
+      existingArtifacts: projectArtifactsForSelection,
+    });
 
-    const newArtifacts = template.artifacts
-      .filter(blueprint => !existingTitles.has(blueprint.title.toLowerCase()))
-      .map((blueprint, index) => ({
-        id: `art-${timestamp + index}`,
-        ownerId: profile.uid,
-        projectId: selectedProjectId,
-        title: blueprint.title,
-        type: blueprint.type,
-        summary: blueprint.summary,
-        status: blueprint.status ?? 'draft',
-        tags: blueprint.tags ? [...blueprint.tags] : [],
-        relations: [],
-        data: blueprint.data ?? getDefaultDataForType(blueprint.type, blueprint.title),
-      }));
+    if (outcome.createdArtifacts.length > 0) {
+      setArtifacts(prev => [...prev, ...outcome.createdArtifacts]);
+      setSelectedArtifactId(outcome.createdArtifacts[0].id);
+    }
 
-    if (newArtifacts.length > 0) {
-      setArtifacts(prev => [...prev, ...newArtifacts]);
-      addXp(newArtifacts.length * 5);
-      setSelectedArtifactId(newArtifacts[0].id);
-      alert(`Added ${newArtifacts.length} starter artifact${newArtifacts.length > 1 ? 's' : ''} from the ${template.name} template.`);
-    } else {
-      alert('All of the template\'s starter artifacts already exist in this project.');
+    if (outcome.xpAwarded > 0) {
+      addXp(outcome.xpAwarded);
     }
 
     if (template.projectTags.length > 0) {
@@ -686,7 +736,10 @@ export default function App() {
         return changed ? next : prev;
       });
     }
-  }, [profile, selectedProjectId, artifacts, setArtifacts, addXp, setProjects]);
+
+    const summary = buildTemplateSummary(template, outcome);
+    return summary;
+  }, [profile, selectedProjectId, selectedProject, artifacts, setArtifacts, addXp, setProjects]);
 
   const handleImportClick = () => {
     fileInputRef.current?.click();

--- a/code/components/ProjectTemplatePicker.tsx
+++ b/code/components/ProjectTemplatePicker.tsx
@@ -1,12 +1,12 @@
-import React, { useMemo } from 'react';
-import { ProjectTemplate, TemplateCategory } from '../types';
+import React, { useCallback, useMemo, useState } from 'react';
+import { ProjectTemplate, TemplateApplicationSummary, TemplateCategory } from '../types';
 import { FolderPlusIcon, SparklesIcon } from './Icons';
 
 interface ProjectTemplatePickerProps {
   templates: ProjectTemplate[];
   categories: TemplateCategory[];
   activeProjectTitle?: string;
-  onApplyTemplate: (template: ProjectTemplate) => void;
+  onApplyTemplate: (template: ProjectTemplate) => Promise<TemplateApplicationSummary>;
   isApplyDisabled?: boolean;
 }
 
@@ -17,6 +17,16 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
   onApplyTemplate,
   isApplyDisabled = false,
 }) => {
+  const [pendingTemplateId, setPendingTemplateId] = useState<string | null>(null);
+  const [status, setStatus] = useState<
+    | {
+        summary: TemplateApplicationSummary;
+        kind: 'success' | 'info' | 'error';
+        message: string;
+      }
+    | null
+  >(null);
+
   const categoryIndex = useMemo(() => {
     const index = new Map<string, TemplateCategory>();
     categories.forEach((category) => {
@@ -24,6 +34,60 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
     });
     return index;
   }, [categories]);
+
+  const describeSummary = useCallback(
+    (template: ProjectTemplate, summary: TemplateApplicationSummary) => {
+      const createdCount = summary.createdTitles.length;
+      const skippedCount = summary.skippedTitles.length;
+
+      const parts: string[] = [];
+      if (createdCount > 0) {
+        parts.push(`${createdCount} ${createdCount === 1 ? 'artifact' : 'artifacts'} created`);
+      }
+      if (skippedCount > 0) {
+        parts.push(`${skippedCount} duplicate${skippedCount === 1 ? '' : 's'} skipped`);
+      }
+
+      const xpSnippet = summary.xpAwarded > 0 ? `+${summary.xpAwarded} XP awarded` : 'No XP awarded';
+      const activity = parts.length > 0 ? parts.join(' • ') : 'No new artifacts were created';
+      return `${template.name}: ${activity} (${xpSnippet})`;
+    },
+    []
+  );
+
+  const handleTemplateApply = useCallback(
+    async (template: ProjectTemplate) => {
+      if (isApplyDisabled) {
+        return;
+      }
+
+      setPendingTemplateId(template.id);
+      try {
+        const summary = await onApplyTemplate(template);
+        const kind: 'success' | 'info' = summary.createdTitles.length > 0 ? 'success' : 'info';
+        setStatus({
+          summary,
+          kind,
+          message: describeSummary(template, summary),
+        });
+      } catch (error) {
+        console.error('Failed to apply template kit', error);
+        setStatus({
+          summary: {
+            templateId: template.id,
+            createdTitles: [],
+            skippedTitles: [],
+            xpAwarded: 0,
+          },
+          kind: 'error',
+          message: `${template.name}: Something went wrong while applying this kit. Please try again.`,
+        });
+      } finally {
+        setPendingTemplateId(null);
+      }
+    },
+    [describeSummary, isApplyDisabled, onApplyTemplate]
+  );
 
   const { recommended, others } = useMemo(() => {
     if (!activeProjectTitle) {
@@ -43,6 +107,14 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
     const linkedCategories = (template.relatedCategoryIds ?? [])
       .map((categoryId) => categoryIndex.get(categoryId))
       .filter((category): category is TemplateCategory => Boolean(category));
+    const isPending = pendingTemplateId === template.id;
+    const disabled = isApplyDisabled || isPending;
+    const statusForTemplate = status?.summary.templateId === template.id ? status : null;
+    const buttonLabel = disabled
+      ? isApplyDisabled
+        ? 'Select a project to apply'
+        : 'Seeding...'
+      : `Apply to ${activeProjectTitle ?? 'project'}`;
 
     return (
       <div
@@ -85,6 +157,17 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
           )}
         </header>
 
+        {template.dashboardHints && template.dashboardHints.length > 0 && (
+          <div className="bg-slate-800/30 border border-slate-700/40 rounded-lg p-3">
+            <div className="text-[10px] uppercase tracking-wide text-slate-400">Dashboard hints</div>
+            <ul className="mt-2 space-y-1 list-disc list-inside text-xs text-slate-300">
+              {template.dashboardHints.map((hint) => (
+                <li key={hint}>{hint}</li>
+              ))}
+            </ul>
+          </div>
+        )}
+
         <div className="space-y-3">
           {template.artifacts.map((artifact) => (
             <div key={artifact.title} className="bg-slate-800/40 border border-slate-700/50 rounded-lg px-3 py-2">
@@ -94,20 +177,62 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
             </div>
           ))}
         </div>
-
+        <div className="flex items-center justify-between text-[11px] uppercase tracking-wide text-slate-500">
+          <span>
+            Kit XP: {template.xpReward ?? 0} • Artifact XP: {template.artifactXpReward ?? 5}
+          </span>
+          {isPending && <span className="text-cyan-300 animate-pulse">Seeding…</span>}
+        </div>
         <button
           type="button"
-          onClick={() => onApplyTemplate(template)}
-          disabled={isApplyDisabled}
+          onClick={() => handleTemplateApply(template)}
+          disabled={disabled}
           className={`flex items-center justify-center gap-2 w-full px-4 py-2 text-sm font-semibold rounded-md transition-colors border
-          ${isApplyDisabled
+          ${disabled
             ? 'cursor-not-allowed text-slate-500 bg-slate-800/80 border-slate-700'
             : 'text-cyan-100 bg-cyan-600/80 hover:bg-cyan-500 border-cyan-500/60'
           }`}
         >
           <FolderPlusIcon className="w-4 h-4" />
-          {isApplyDisabled ? 'Select a project to apply' : `Apply to ${activeProjectTitle ?? 'project'}`}
+          {buttonLabel}
         </button>
+        {statusForTemplate && (
+          <div
+            className={`rounded-lg border px-3 py-3 text-xs space-y-2 ${
+              statusForTemplate.kind === 'error'
+                ? 'border-rose-500/40 bg-rose-950/40 text-rose-200'
+                : 'border-cyan-500/40 bg-cyan-900/30 text-cyan-100'
+            }`}
+          >
+            <div className="text-[10px] font-semibold uppercase tracking-wide">
+              {statusForTemplate.kind === 'error' ? 'Hydration failed' : 'Hydration summary'}
+            </div>
+            <p className="text-xs leading-relaxed">{statusForTemplate.message}</p>
+            {statusForTemplate.summary.createdTitles.length > 0 && (
+              <div>
+                <div className="text-[10px] uppercase tracking-wide text-slate-400">Created</div>
+                <ul className="mt-1 space-y-0.5 text-xs text-slate-200">
+                  {statusForTemplate.summary.createdTitles.map((title) => (
+                    <li key={`created-${title}`}>• {title}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {statusForTemplate.summary.skippedTitles.length > 0 && (
+              <div>
+                <div className="text-[10px] uppercase tracking-wide text-slate-400">Skipped</div>
+                <ul className="mt-1 space-y-0.5 text-xs text-slate-300">
+                  {statusForTemplate.summary.skippedTitles.map((title) => (
+                    <li key={`skipped-${title}`}>• {title}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <div className="text-[10px] uppercase tracking-wide text-slate-400">
+              XP Awarded: {statusForTemplate.summary.xpAwarded}
+            </div>
+          </div>
+        )}
       </div>
     );
   };

--- a/code/types.ts
+++ b/code/types.ts
@@ -156,6 +156,12 @@ export interface Achievement {
     isUnlocked: (artifacts: Artifact[], projects: Project[]) => boolean;
 }
 
+export interface TemplateRelationBlueprint {
+    toBlueprintId?: string;
+    toExistingTitle?: string;
+    kind: string;
+}
+
 export interface TemplateArtifactBlueprint {
     title: string;
     type: ArtifactType;
@@ -163,6 +169,9 @@ export interface TemplateArtifactBlueprint {
     status?: string;
     tags?: string[];
     data?: Artifact['data'];
+    relations?: TemplateRelationBlueprint[];
+    xpReward?: number;
+    blueprintId?: string;
 }
 
 export interface ProjectTemplate {
@@ -173,6 +182,16 @@ export interface ProjectTemplate {
     relatedCategoryIds?: string[];
     projectTags: string[];
     artifacts: TemplateArtifactBlueprint[];
+    xpReward?: number;
+    artifactXpReward?: number;
+    dashboardHints?: string[];
+}
+
+export interface TemplateApplicationSummary {
+    templateId: string;
+    createdTitles: string[];
+    skippedTitles: string[];
+    xpAwarded: number;
 }
 
 export interface TemplateEntry {

--- a/code/utils/artifactDefaults.ts
+++ b/code/utils/artifactDefaults.ts
@@ -1,0 +1,64 @@
+import { Artifact, ArtifactType, TaskData, TaskState } from '../types';
+
+type MaybeRecord = Record<string, unknown> | undefined;
+
+type Mergeable = Artifact['data'];
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> => {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+};
+
+const deepMerge = (target: Mergeable, source: Mergeable): Mergeable => {
+  if (Array.isArray(target)) {
+    return Array.isArray(source) ? source : target;
+  }
+
+  if (isPlainObject(target)) {
+    const merged: MaybeRecord = { ...(target as Record<string, unknown>) };
+    if (isPlainObject(source)) {
+      Object.entries(source).forEach(([key, value]) => {
+        const existing = (merged as Record<string, unknown>)[key];
+        if (Array.isArray(existing) || Array.isArray(value)) {
+          (merged as Record<string, unknown>)[key] = Array.isArray(value) ? value : existing;
+          return;
+        }
+        if (isPlainObject(existing) && isPlainObject(value)) {
+          (merged as Record<string, unknown>)[key] = deepMerge(existing as Mergeable, value as Mergeable);
+          return;
+        }
+        (merged as Record<string, unknown>)[key] = value;
+      });
+    }
+    return merged ?? target;
+  }
+
+  return source ?? target;
+};
+
+export const getDefaultDataForType = (type: ArtifactType, title?: string): Artifact['data'] => {
+  switch (type) {
+    case ArtifactType.Conlang:
+      return [];
+    case ArtifactType.Story:
+    case ArtifactType.Scene:
+      return [];
+    case ArtifactType.Task:
+      return { state: TaskState.Todo } as TaskData;
+    case ArtifactType.Character:
+      return { bio: '', traits: [] };
+    case ArtifactType.Wiki:
+      return { content: `# ${title ?? 'Untitled'}\n\n` };
+    case ArtifactType.Location:
+      return { description: '', features: [] };
+    default:
+      return {};
+  }
+};
+
+export const composeSeedData = (type: ArtifactType, provided: Artifact['data'] | undefined, title?: string): Artifact['data'] => {
+  const defaults = getDefaultDataForType(type, title);
+  if (provided === undefined) {
+    return defaults;
+  }
+  return deepMerge(defaults, provided);
+};

--- a/code/utils/templateHydrator.ts
+++ b/code/utils/templateHydrator.ts
@@ -1,0 +1,169 @@
+import { Artifact, ProjectTemplate, TemplateApplicationSummary, TemplateArtifactBlueprint } from '../types';
+import { composeSeedData } from './artifactDefaults';
+
+interface HydrateTemplateOptions {
+  template: ProjectTemplate;
+  ownerId: string;
+  projectId: string;
+  projectTitle: string;
+  existingArtifacts: Artifact[];
+}
+
+interface HydrationOutcome {
+  createdArtifacts: Artifact[];
+  skippedBlueprints: TemplateArtifactBlueprint[];
+  xpAwarded: number;
+  projectTitle: string;
+}
+
+const normalizeTitle = (value: string) => value.trim().toLowerCase().replace(/\s+/g, ' ');
+
+const applyProjectTokens = (value: string | undefined, projectTitle: string) => {
+  if (!value) return value ?? '';
+  return value.replace(/\{\{\s*project\s*\}\}/gi, projectTitle);
+};
+
+const resolveBlueprintId = (blueprint: TemplateArtifactBlueprint) => {
+  if (blueprint.blueprintId) {
+    return blueprint.blueprintId;
+  }
+  return blueprint.title.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-');
+};
+
+const generateStableId = (
+  templateId: string,
+  blueprint: TemplateArtifactBlueprint,
+  takenIds: Set<string>
+) => {
+  const base = `tmpl-${templateId}-${resolveBlueprintId(blueprint)}`;
+  if (!takenIds.has(base)) {
+    takenIds.add(base);
+    return base;
+  }
+  let counter = 1;
+  let candidate = `${base}-${counter}`;
+  while (takenIds.has(candidate)) {
+    counter += 1;
+    candidate = `${base}-${counter}`;
+  }
+  takenIds.add(candidate);
+  return candidate;
+};
+
+export const hydrateTemplate = ({
+  template,
+  ownerId,
+  projectId,
+  projectTitle,
+  existingArtifacts,
+}: HydrateTemplateOptions): HydrationOutcome => {
+  const normalizedExisting = new Map<string, Artifact>();
+  const takenIds = new Set(existingArtifacts.map((artifact) => artifact.id));
+
+  existingArtifacts.forEach((artifact) => {
+    normalizedExisting.set(normalizeTitle(artifact.title), artifact);
+  });
+
+  const blueprintToArtifactId = new Map<string, string>();
+  const createdArtifacts: Artifact[] = [];
+  const skippedBlueprints: TemplateArtifactBlueprint[] = [];
+  let xpAwarded = 0;
+
+  const fallbackArtifactXp = template.artifactXpReward ?? 5;
+
+  template.artifacts.forEach((blueprint) => {
+    const hydratedTitle = applyProjectTokens(blueprint.title, projectTitle);
+    const normalizedTitle = normalizeTitle(hydratedTitle);
+    const existing = normalizedExisting.get(normalizedTitle);
+
+    if (existing) {
+      blueprintToArtifactId.set(resolveBlueprintId(blueprint), existing.id);
+      skippedBlueprints.push(blueprint);
+      return;
+    }
+
+    const artifactId = generateStableId(template.id, blueprint, takenIds);
+
+    const artifact: Artifact = {
+      id: artifactId,
+      ownerId,
+      projectId,
+      type: blueprint.type,
+      title: hydratedTitle,
+      summary: applyProjectTokens(blueprint.summary, projectTitle),
+      status: blueprint.status ?? 'draft',
+      tags: blueprint.tags ? [...blueprint.tags] : [],
+      relations: [],
+      data: composeSeedData(blueprint.type, blueprint.data, hydratedTitle),
+    };
+
+    const artifactXp = blueprint.xpReward ?? fallbackArtifactXp;
+    xpAwarded += artifactXp;
+
+    blueprintToArtifactId.set(resolveBlueprintId(blueprint), artifact.id);
+    createdArtifacts.push(artifact);
+    normalizedExisting.set(normalizedTitle, artifact);
+  });
+
+  template.artifacts.forEach((blueprint) => {
+    if (!blueprint.relations || blueprint.relations.length === 0) {
+      return;
+    }
+
+    const sourceId = blueprintToArtifactId.get(resolveBlueprintId(blueprint));
+    if (!sourceId) {
+      return;
+    }
+
+    const artifact = createdArtifacts.find((item) => item.id === sourceId);
+    if (!artifact) {
+      return;
+    }
+
+    const relations = blueprint.relations
+      .map((relation) => {
+        if (relation.toBlueprintId) {
+          const targetId = blueprintToArtifactId.get(relation.toBlueprintId);
+          if (targetId) {
+            return { toId: targetId, kind: relation.kind };
+          }
+        }
+        if (relation.toExistingTitle) {
+          const normalized = normalizeTitle(applyProjectTokens(relation.toExistingTitle, projectTitle));
+          const existing = normalizedExisting.get(normalized);
+          if (existing) {
+            return { toId: existing.id, kind: relation.kind };
+          }
+        }
+        return null;
+      })
+      .filter((relation): relation is { toId: string; kind: string } => Boolean(relation));
+
+    artifact.relations = relations;
+  });
+
+  if (createdArtifacts.length > 0) {
+    xpAwarded += template.xpReward ?? 0;
+  }
+
+  return {
+    createdArtifacts,
+    skippedBlueprints,
+    xpAwarded,
+    projectTitle,
+  };
+};
+
+export const buildTemplateSummary = (
+  template: ProjectTemplate,
+  outcome: HydrationOutcome
+): TemplateApplicationSummary => {
+  return {
+    templateId: template.id,
+    createdTitles: outcome.createdArtifacts.map((artifact) => artifact.title),
+    skippedTitles: outcome.skippedBlueprints.map((blueprint) =>
+      applyProjectTokens(blueprint.title, outcome.projectTitle)
+    ),
+    xpAwarded: outcome.xpAwarded,
+  };
+};


### PR DESCRIPTION
## Summary
- add a template hydrator utility that generates stable IDs, reconnects relations, and applies XP rewards while tokenizing titles
- enrich project templates with per-kit metadata, relation-aware blueprints, and dashboard hints to seed richer starter content
- upgrade the project template picker with loading states, gating, and hydration summaries instead of the old documentation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6900ea822d2c8328a8bb92f9b7b510e7