### PR TITLE
Ensure release note drafts reset when switching projects

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1045,6 +1045,7 @@ export default function App() {
                   />
                 </div>
                 <ReleaseNotesGenerator
+                    projectId={selectedProject.id}
                     projectTitle={selectedProject.title}
                     artifacts={projectArtifacts}
                     addXp={addXp}

--- a/code/components/ReleaseNotesGenerator.tsx
+++ b/code/components/ReleaseNotesGenerator.tsx
@@ -4,6 +4,7 @@ import { generateReleaseNotes } from '../services/geminiService';
 import { MegaphoneIcon, SparklesIcon, Spinner } from './Icons';
 
 interface ReleaseNotesGeneratorProps {
+  projectId: string;
   projectTitle: string;
   artifacts: Artifact[];
   addXp: (amount: number) => void;
@@ -16,7 +17,12 @@ const formatListPreview = (items: string[], max = 3): string => {
   return remainder > 0 ? `${preview} +${remainder} more` : preview;
 };
 
-const ReleaseNotesGenerator: React.FC<ReleaseNotesGeneratorProps> = ({ projectTitle, artifacts, addXp }) => {
+const ReleaseNotesGenerator: React.FC<ReleaseNotesGeneratorProps> = ({
+  projectId,
+  projectTitle,
+  artifacts,
+  addXp,
+}) => {
   const [tone, setTone] = useState('playful');
   const [audience, setAudience] = useState('collaborators');
   const [highlights, setHighlights] = useState('');
@@ -88,7 +94,7 @@ const ReleaseNotesGenerator: React.FC<ReleaseNotesGeneratorProps> = ({ projectTi
     setHighlights(autoHighlights);
     // Reset when viewing a different project so earlier drafts don't leak across worlds.
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally omit autoHighlights to keep manual edits when artifacts change.
-  }, [projectTitle]);
+  }, [projectId, projectTitle]);
 
   const handleGenerate = useCallback(async () => {
     setIsGenerating(true);

--- a/code/components/__tests__/ReleaseNotesGenerator.test.tsx
+++ b/code/components/__tests__/ReleaseNotesGenerator.test.tsx
@@ -62,7 +62,12 @@ describe('ReleaseNotesGenerator', () => {
   it('prefills highlights from artifact activity', async () => {
     const addXp = vi.fn();
     render(
-      <ReleaseNotesGenerator projectTitle="Tamenzut" artifacts={baseArtifacts} addXp={addXp} />,
+      <ReleaseNotesGenerator
+        projectId="project-tamenzut"
+        projectTitle="Tamenzut"
+        artifacts={baseArtifacts}
+        addXp={addXp}
+      />,
     );
 
     const highlightsField = screen.getByLabelText(/Highlights to share/i) as HTMLTextAreaElement;
@@ -79,7 +84,12 @@ describe('ReleaseNotesGenerator', () => {
     mockedGenerateReleaseNotes.mockResolvedValue('Here are the new release notes!');
 
     render(
-      <ReleaseNotesGenerator projectTitle="Tamenzut" artifacts={baseArtifacts} addXp={addXp} />,
+      <ReleaseNotesGenerator
+        projectId="project-tamenzut"
+        projectTitle="Tamenzut"
+        artifacts={baseArtifacts}
+        addXp={addXp}
+      />,
     );
 
     const highlightsField = screen.getByLabelText(/Highlights to share/i) as HTMLTextAreaElement;
@@ -112,7 +122,12 @@ describe('ReleaseNotesGenerator', () => {
     mockedGenerateReleaseNotes.mockResolvedValue('Here are the new release notes!');
 
     const { rerender } = render(
-      <ReleaseNotesGenerator projectTitle="Tamenzut" artifacts={baseArtifacts} addXp={addXp} />,
+      <ReleaseNotesGenerator
+        projectId="project-tamenzut"
+        projectTitle="Tamenzut"
+        artifacts={baseArtifacts}
+        addXp={addXp}
+      />,
     );
 
     const highlightsField = screen.getByLabelText(/Highlights to share/i) as HTMLTextAreaElement;
@@ -127,7 +142,12 @@ describe('ReleaseNotesGenerator', () => {
     });
 
     rerender(
-      <ReleaseNotesGenerator projectTitle="Steamweave" artifacts={baseArtifacts} addXp={addXp} />,
+      <ReleaseNotesGenerator
+        projectId="project-steamweave"
+        projectTitle="Steamweave"
+        artifacts={baseArtifacts}
+        addXp={addXp}
+      />,
     );
 
     await waitFor(() => {
@@ -144,7 +164,12 @@ describe('ReleaseNotesGenerator', () => {
     const user = userEvent.setup();
     const addXp = vi.fn();
     const { rerender } = render(
-      <ReleaseNotesGenerator projectTitle="Tamenzut" artifacts={baseArtifacts} addXp={addXp} />,
+      <ReleaseNotesGenerator
+        projectId="project-tamenzut"
+        projectTitle="Tamenzut"
+        artifacts={baseArtifacts}
+        addXp={addXp}
+      />,
     );
 
     const highlightsField = screen.getByLabelText(/Highlights to share/i) as HTMLTextAreaElement;
@@ -153,6 +178,7 @@ describe('ReleaseNotesGenerator', () => {
 
     rerender(
       <ReleaseNotesGenerator
+        projectId="project-tamenzut"
         projectTitle="Tamenzut"
         artifacts={[...baseArtifacts, { ...baseArtifacts[1], id: 'story-2', title: 'Chapter Two' }]}
         addXp={addXp}


### PR DESCRIPTION
## Summary
- ensure the ReleaseNotesGenerator receives a stable projectId so drafts reset when switching projects
- pass the selected project id from the workspace shell and keep manual highlight edits when artifacts change
- update unit tests to reflect the new prop and protect the regression

## Testing
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69012a70b8cc83288a2f71fbbe8d0a43