### PR TITLE
Add Darv language primer documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A playful, gamified personal knowledge system for organizing web comics, wikis, websites, games, GitHub repos, stories, conlangs, AI‑ and hand‑written novels, and more — with both creative canvases and tabular import/export.
 
+📘 Lore reference: see [`docs/darv-language.md`](docs/darv-language.md) for the Darv language primer that anchors Tamenzut rituals, myths, and conlang work.
+
 ## Product Roadmap
 
 ### Phase 1 — Seed the Universe (Weeks 0‑4)

--- a/docs/darv-language.md
+++ b/docs/darv-language.md
@@ -1,0 +1,24 @@
+# Darv Language Primer
+
+Darv is the ritual and mythic language that threads through the Tamenzut setting. This primer captures the key concepts established across earlier lexicon passes and narrative experiments so the world bible can reference a single source of truth.
+
+## Core Meaning
+- **Semantic root:** The word *darv* translates simultaneously to “word,” “say,” and “language,” reflecting the tongue’s reflexive, self-aware nature.
+- **Compound logic:** Vocabulary often carries dual or layered interpretations. A single lexeme can represent seemingly opposing concepts (e.g., “shadow” and “truth”), with context and speaker intonation resolving the meaning.
+- **Rhythmic grammar:** Sentences follow a compact Subject–Verb–Object ordering similar to English, with multipurpose words bridging body, spirit, and elemental domains.
+
+## Usage and Tone
+- **Cultural role:** Darv is preserved by monks, priests, and scholars who trace their lineage to the Edruel civilization or its mythic successors.
+- **Literary tradition:** The language appears throughout parables, horror tales, and sacred myths such as *Gish vit Plahk* and *Goma Vit Droo-Dum*, where layered meanings reinforce moral or cosmic revelations.
+- **Ritual speech:** Ceremonies and invocations use Darv to bind oaths, reveal hidden histories, or summon ancestral memories, leaning on the language’s compound semantics to veil and unveil truths simultaneously.
+
+## Lexicon Evolution
+- **Versioning:** Lexicon iterations (v1.0 → v2.0) broaden narrowly defined terms into symbolic clusters. For example, utilitarian words like *cd* (originally “poop”) gain metaphorical dimensions tied to decay, fertile soil, or cyclical renewal.
+- **Design principle:** Updates emphasize polyvalence—each revision seeks to connect bodily imagery with spiritual or elemental resonances, keeping the language adaptable for new stories.
+
+## Narrative Integration
+- **Tamenzut projects:** Within Creative Atlas artifacts, Darv anchors faction mottos, ritual scripts, and horror set pieces. Writers use it to contrast mortal perception with ancient logic.
+- **Cross-artifact consistency:** When expanding the lexicon or authoring new myths, align with the compound-meaning ethos and note any shifts in the shared spreadsheet or conlang editor templates.
+
+---
+*Last updated: 2025-10-29*


### PR DESCRIPTION
## Summary
- add a dedicated Darv language primer that captures its compound semantics, usage, and lexicon evolution
- surface the new lore reference in the main README so world builders can find the primer quickly

## Testing
- not run (documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_690175567e5c8328ae32e673314b4b61