### PR TITLE
Add milestone tracker with roadmap progress insights

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -45,6 +45,8 @@ import { useAuth } from './contexts/AuthContext';
 import UserProfileCard from './components/UserProfileCard';
 import GitHubImportPanel from './components/GitHubImportPanel';
 import SecondaryInsightsPanel from './components/SecondaryInsightsPanel';
+import MilestoneTracker from './components/MilestoneTracker';
+import { createProjectActivity, evaluateMilestoneProgress, MilestoneProgressOverview, ProjectActivity } from './utils/milestoneProgress';
 
 const dailyQuests: Quest[] = [
     { id: 'q1', title: 'First Seed', description: 'Create at least one new artifact.', isCompleted: (artifacts) => artifacts.length > 7, xp: 5 },
@@ -326,10 +328,26 @@ const milestoneRoadmap: Milestone[] = [
         timeline: 'Weeks 1–4',
         focus: 'Ship the graph-native core so ideas can be captured, linked, and exported.',
         objectives: [
-            'Core graph model, Projects/Artifacts/Relations',
-            'Seed capture, Table view, basic Graph view',
-            'CSV import/export (artifacts, relations)',
-            'GitHub read-only import (repos/issues/releases)',
+            {
+                id: 'm1-core-graph',
+                description: 'Core graph model, Projects/Artifacts/Relations',
+                metric: 'graph-core',
+            },
+            {
+                id: 'm1-seed-capture',
+                description: 'Seed capture, Table view, basic Graph view',
+                metric: 'view-engagement',
+            },
+            {
+                id: 'm1-csv-flows',
+                description: 'CSV import/export (artifacts, relations)',
+                metric: 'csv-flows',
+            },
+            {
+                id: 'm1-github-import',
+                description: 'GitHub read-only import (repos/issues/releases)',
+                metric: 'github-import',
+            },
         ],
     },
     {
@@ -338,9 +356,21 @@ const milestoneRoadmap: Milestone[] = [
         timeline: 'Weeks 5–8',
         focus: 'Deepen creation flows with rich editors and playful progression loops.',
         objectives: [
-            'Conlang table editor; Storyboard; Kanban',
-            'XP/Streaks/Quests + Achievements',
-            'Markdown bundle export',
+            {
+                id: 'm2-rich-editors',
+                description: 'Conlang table editor; Storyboard; Kanban',
+                metric: 'rich-editors',
+            },
+            {
+                id: 'm2-progression',
+                description: 'XP/Streaks/Quests + Achievements',
+                metric: 'progression-loops',
+            },
+            {
+                id: 'm2-markdown',
+                description: 'Markdown bundle export',
+                metric: 'markdown-export',
+            },
         ],
     },
     {
@@ -349,9 +379,21 @@ const milestoneRoadmap: Milestone[] = [
         timeline: 'Weeks 9–12',
         focus: 'Publish worlds outward with search, release tooling, and static sites.',
         objectives: [
-            'Static site exporter (Wikis/Docs)',
-            'Release notes generator',
-            'Search (Meilisearch), advanced filters',
+            {
+                id: 'm3-static-site',
+                description: 'Static site exporter (Wikis/Docs)',
+                metric: 'static-site',
+            },
+            {
+                id: 'm3-release-bard',
+                description: 'Release notes generator',
+                metric: 'release-notes',
+            },
+            {
+                id: 'm3-search',
+                description: 'Search (Meilisearch), advanced filters',
+                metric: 'search-filters',
+            },
         ],
     },
     {
@@ -360,8 +402,16 @@ const milestoneRoadmap: Milestone[] = [
         timeline: 'Weeks 13–16',
         focus: 'Open the universe with plugins, theming, and offline-friendly polish.',
         objectives: [
-            'Plugin API + 3 sample plugins (conlang, webcomic, ai prompts)',
-            'Theming, keyboard palette, offline cache (light)',
+            {
+                id: 'm4-plugin-api',
+                description: 'Plugin API + 3 sample plugins (conlang, webcomic, ai prompts)',
+                metric: 'plugin-api',
+            },
+            {
+                id: 'm4-theming-offline',
+                description: 'Theming, keyboard palette, offline cache (light)',
+                metric: 'theming-offline',
+            },
         ],
     },
 ];
@@ -525,6 +575,7 @@ export default function App() {
   const [searchTerm, setSearchTerm] = useState('');
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isInsightsOpen, setIsInsightsOpen] = useState(false);
+  const [projectActivityLog, setProjectActivityLog] = useState<Record<string, ProjectActivity>>({});
 
   useEffect(() => {
     if (!projects.length) {
@@ -537,6 +588,70 @@ export default function App() {
       setSelectedArtifactId(null);
     }
   }, [projects, selectedProjectId]);
+
+  useEffect(() => {
+    if (!selectedProjectId) {
+      return;
+    }
+
+    setProjectActivityLog((prev) => {
+      if (prev[selectedProjectId]) {
+        return prev;
+      }
+      return {
+        ...prev,
+        [selectedProjectId]: createProjectActivity(),
+      };
+    });
+  }, [selectedProjectId]);
+
+  const updateProjectActivity = useCallback((projectId: string, updates: Partial<ProjectActivity>) => {
+    setProjectActivityLog((prev) => {
+      const current = prev[projectId] ?? createProjectActivity();
+      let changed = false;
+      const next: ProjectActivity = { ...current };
+
+      (Object.entries(updates) as [keyof ProjectActivity, boolean][]).forEach(([key, value]) => {
+        if (typeof value === 'undefined') {
+          return;
+        }
+        if (next[key] !== value) {
+          next[key] = value;
+          changed = true;
+        }
+      });
+
+      if (!changed && prev[projectId]) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        [projectId]: changed ? next : current,
+      };
+    });
+  }, []);
+
+  const markSelectedProjectActivity = useCallback((updates: Partial<ProjectActivity>) => {
+    if (!selectedProjectId) {
+      return;
+    }
+    updateProjectActivity(selectedProjectId, updates);
+  }, [selectedProjectId, updateProjectActivity]);
+
+  useEffect(() => {
+    if (searchTerm.trim() === '') {
+      return;
+    }
+    markSelectedProjectActivity({ usedSearch: true });
+  }, [searchTerm, markSelectedProjectActivity]);
+
+  useEffect(() => {
+    if (artifactTypeFilter === 'ALL' && statusFilter === 'ALL') {
+      return;
+    }
+    markSelectedProjectActivity({ usedFilters: true });
+  }, [artifactTypeFilter, statusFilter, markSelectedProjectActivity]);
 
   useEffect(() => {
     if (!profile) return;
@@ -705,12 +820,13 @@ export default function App() {
             const existingIds = new Set(artifacts.map(a => a.id));
             const newArtifacts = imported.filter(i => !existingIds.has(i.id));
 
-            if (newArtifacts.length > 0) {
-                setArtifacts(prev => [...prev, ...newArtifacts]);
-                alert(`${newArtifacts.length} new artifacts imported successfully!`);
-            } else {
-                alert('No new artifacts to import. All IDs in the file already exist.');
-            }
+      if (newArtifacts.length > 0) {
+        setArtifacts(prev => [...prev, ...newArtifacts]);
+        alert(`${newArtifacts.length} new artifacts imported successfully!`);
+        markSelectedProjectActivity({ importedCsv: true });
+      } else {
+        alert('No new artifacts to import. All IDs in the file already exist.');
+      }
         } catch (error) {
             alert(`Import failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
         }
@@ -725,11 +841,16 @@ export default function App() {
     }
 
     setArtifacts(prev => [...prev, ...newArtifacts]);
-  }, [setArtifacts]);
+    const projectId = newArtifacts[0]?.projectId ?? selectedProjectId;
+    if (projectId) {
+      updateProjectActivity(projectId, { githubImported: true });
+    }
+  }, [setArtifacts, selectedProjectId, updateProjectActivity]);
 
   const handlePublish = () => {
     if (selectedProject && projectArtifacts.length > 0) {
         exportProjectAsStaticSite(selectedProject, projectArtifacts);
+        markSelectedProjectActivity({ publishedSite: true });
         addXp(25); // XP Source: publish (+25)
     } else {
         alert('Please select a project with artifacts to publish.');
@@ -740,6 +861,24 @@ export default function App() {
   const projectArtifacts = useMemo(() => artifacts.filter(a => a.projectId === selectedProjectId), [artifacts, selectedProjectId]);
   const selectedArtifact = useMemo(() => artifacts.find(a => a.id === selectedArtifactId), [artifacts, selectedArtifactId]);
   const availableStatuses = useMemo(() => Array.from(new Set(projectArtifacts.map(artifact => artifact.status))).sort(), [projectArtifacts]);
+  const emptyActivity = useMemo(() => createProjectActivity(), []);
+  const selectedProjectActivity = useMemo(() => {
+    if (!selectedProjectId) {
+      return emptyActivity;
+    }
+    return projectActivityLog[selectedProjectId] ?? emptyActivity;
+  }, [projectActivityLog, selectedProjectId, emptyActivity]);
+  const milestoneProgress = useMemo<MilestoneProgressOverview[]>(() => {
+    if (!selectedProject) {
+      return [];
+    }
+    return evaluateMilestoneProgress(milestoneRoadmap, {
+      project: selectedProject,
+      artifacts: projectArtifacts,
+      profile,
+      activity: selectedProjectActivity,
+    });
+  }, [selectedProject, projectArtifacts, profile, selectedProjectActivity]);
 
   const handleProfileUpdate = useCallback((updates: { displayName?: string; settings?: Partial<UserProfile['settings']> }) => {
     updateProfile(updates);
@@ -791,15 +930,37 @@ export default function App() {
     setSearchTerm('');
   };
 
+  const handleExportArtifacts = useCallback((format: 'csv' | 'tsv') => {
+    if (!selectedProject) {
+      return;
+    }
+    markSelectedProjectActivity({ exportedData: true });
+    if (format === 'csv') {
+      exportArtifactsToCSV(projectArtifacts, selectedProject.title);
+    } else {
+      exportArtifactsToTSV(projectArtifacts, selectedProject.title);
+    }
+  }, [selectedProject, projectArtifacts, markSelectedProjectActivity]);
+
+  const handleViewModeChange = useCallback((mode: 'table' | 'graph' | 'kanban') => {
+    setViewMode(mode);
+    if (mode === 'graph') {
+      markSelectedProjectActivity({ viewedGraph: true });
+    }
+    if (mode === 'kanban') {
+      markSelectedProjectActivity({ viewedKanban: true });
+    }
+  }, [markSelectedProjectActivity]);
+
   const ViewSwitcher = () => (
     <div className="flex items-center gap-1 p-1 bg-slate-700/50 rounded-lg">
-        <button onClick={() => setViewMode('table')} className={`flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors ${viewMode === 'table' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:bg-slate-700'}`}>
+        <button onClick={() => handleViewModeChange('table')} className={`flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors ${viewMode === 'table' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:bg-slate-700'}`}>
             <TableCellsIcon className="w-4 h-4" /> Table
         </button>
-        <button onClick={() => setViewMode('graph')} className={`flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors ${viewMode === 'graph' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:bg-slate-700'}`}>
+        <button onClick={() => handleViewModeChange('graph')} className={`flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors ${viewMode === 'graph' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:bg-slate-700'}`}>
             <ShareIcon className="w-4 h-4" /> Graph
         </button>
-        <button onClick={() => setViewMode('kanban')} className={`flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors ${viewMode === 'kanban' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:bg-slate-700'}`}>
+        <button onClick={() => handleViewModeChange('kanban')} className={`flex items-center gap-2 px-3 py-1 rounded-md text-sm transition-colors ${viewMode === 'kanban' ? 'bg-slate-600 text-white' : 'text-slate-400 hover:bg-slate-700'}`}>
             <ViewColumnsIcon className="w-4 h-4" /> Kanban
         </button>
     </div>
@@ -843,6 +1004,7 @@ export default function App() {
                   onUpdateProject={handleUpdateProject}
               />
               <ProjectInsights artifacts={projectArtifacts} />
+              <MilestoneTracker items={milestoneProgress} />
               <GitHubImportPanel
                   projectId={selectedProject.id}
                   ownerId={profile.uid}
@@ -859,10 +1021,10 @@ export default function App() {
                         <button onClick={handleImportClick} title="Import from CSV or TSV" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
                             <ArrowUpTrayIcon className="w-5 h-5" />
                         </button>
-                        <button onClick={() => exportArtifactsToCSV(projectArtifacts, selectedProject.title)} title="Export to CSV" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
+                        <button onClick={() => handleExportArtifacts('csv')} title="Export to CSV" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
                             <ArrowDownTrayIcon className="w-5 h-5" />
                         </button>
-                        <button onClick={() => exportArtifactsToTSV(projectArtifacts, selectedProject.title)} title="Export to TSV" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
+                        <button onClick={() => handleExportArtifacts('tsv')} title="Export to TSV" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
                             <span className="flex items-center justify-center w-5 h-5 text-xs font-bold">TSV</span>
                         </button>
                         <ViewSwitcher />
@@ -1049,6 +1211,7 @@ export default function App() {
                     projectTitle={selectedProject.title}
                     artifacts={projectArtifacts}
                     addXp={addXp}
+                    onDraftGenerated={() => markSelectedProjectActivity({ generatedReleaseNotes: true })}
                 />
                 <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 flex flex-col gap-5">
                     <header className="flex items-start justify-between gap-4">

--- a/code/components/MilestoneTracker.tsx
+++ b/code/components/MilestoneTracker.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { MilestoneProgressOverview, ObjectiveStatus } from '../utils/milestoneProgress';
+import { FlagIcon, SparklesIcon, CheckCircleIcon, XMarkIcon } from './Icons';
+
+interface MilestoneTrackerProps {
+  items: MilestoneProgressOverview[];
+}
+
+const statusLabel: Record<ObjectiveStatus, string> = {
+  complete: 'Complete',
+  'in-progress': 'In progress',
+  'not-started': 'Not started',
+};
+
+const statusStyles: Record<ObjectiveStatus, string> = {
+  complete: 'bg-emerald-500/15 border-emerald-400/40 text-emerald-200',
+  'in-progress': 'bg-amber-500/15 border-amber-400/40 text-amber-200',
+  'not-started': 'bg-slate-800 border-slate-700 text-slate-400',
+};
+
+const StatusIcon: React.FC<{ status: ObjectiveStatus; className?: string }> = ({ status, className }) => {
+  if (status === 'complete') {
+    return <CheckCircleIcon className={className} />;
+  }
+  if (status === 'in-progress') {
+    return <SparklesIcon className={className} />;
+  }
+  return <XMarkIcon className={className} />;
+};
+
+const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({ items }) => {
+  if (items.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
+      <header className="flex items-center gap-3">
+        <FlagIcon className="w-5 h-5 text-cyan-400" />
+        <div>
+          <h3 className="text-lg font-semibold text-slate-100">Milestone tracker</h3>
+          <p className="text-sm text-slate-400">
+            Layer-two progress signals show how close this project is to each roadmap milestone.
+          </p>
+        </div>
+      </header>
+
+      <div className="space-y-5">
+        {items.map(({ milestone, objectives, completion }) => {
+          const percent = Math.round(completion * 100);
+
+          return (
+            <article
+              key={milestone.id}
+              className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-4 space-y-4 shadow-lg shadow-slate-950/20"
+            >
+              <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{milestone.timeline}</p>
+                  <h4 className="text-lg font-semibold text-slate-200">{milestone.title}</h4>
+                </div>
+                <div className="text-sm font-semibold text-slate-300">
+                  <span className="text-cyan-300">{percent}%</span> ready
+                </div>
+              </div>
+
+              <div className="h-2 w-full rounded-full bg-slate-800 overflow-hidden">
+                <div
+                  className="h-full bg-gradient-to-r from-cyan-400 via-sky-500 to-violet-500 transition-all duration-500"
+                  style={{ width: `${percent}%` }}
+                />
+              </div>
+
+              <p className="text-sm text-slate-400">{milestone.focus}</p>
+
+              <ul className="space-y-2">
+                {objectives.map((objective) => (
+                  <li
+                    key={objective.id}
+                    className="flex flex-col gap-2 rounded-xl border border-slate-800 bg-slate-950/50 p-3 sm:flex-row sm:items-start sm:gap-3"
+                  >
+                    <span
+                      className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${statusStyles[objective.status]}`}
+                    >
+                      <StatusIcon status={objective.status} className="w-4 h-4" />
+                      {statusLabel[objective.status]}
+                    </span>
+                    <div className="space-y-1">
+                      <p className="text-sm font-semibold text-slate-200">{objective.description}</p>
+                      <p className="text-xs text-slate-400 leading-relaxed">{objective.detail}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default MilestoneTracker;

--- a/code/components/ReleaseNotesGenerator.tsx
+++ b/code/components/ReleaseNotesGenerator.tsx
@@ -8,6 +8,7 @@ interface ReleaseNotesGeneratorProps {
   projectTitle: string;
   artifacts: Artifact[];
   addXp: (amount: number) => void;
+  onDraftGenerated?: () => void;
 }
 
 const formatListPreview = (items: string[], max = 3): string => {
@@ -22,6 +23,7 @@ const ReleaseNotesGenerator: React.FC<ReleaseNotesGeneratorProps> = ({
   projectTitle,
   artifacts,
   addXp,
+  onDraftGenerated,
 }) => {
   const [tone, setTone] = useState('playful');
   const [audience, setAudience] = useState('collaborators');
@@ -111,12 +113,15 @@ const ReleaseNotesGenerator: React.FC<ReleaseNotesGeneratorProps> = ({
       });
       setGeneratedNotes(result.trim());
       addXp(7); // XP Source: Release Bard assist (+7)
+      if (onDraftGenerated) {
+        onDraftGenerated();
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to generate release notes.');
     } finally {
       setIsGenerating(false);
     }
-  }, [projectTitle, tone, audience, highlights, notes, addXp]);
+  }, [projectTitle, tone, audience, highlights, notes, addXp, onDraftGenerated]);
 
   const handleCopy = async () => {
     if (!generatedNotes) return;

--- a/code/components/Roadmap.tsx
+++ b/code/components/Roadmap.tsx
@@ -36,11 +36,11 @@ const Roadmap: React.FC<RoadmapProps> = ({ milestones }) => {
             <ul className="space-y-2 text-sm text-slate-300">
               {milestone.objectives.map((objective) => (
                 <li
-                  key={objective}
+                  key={objective.id}
                   className="flex items-start gap-2 bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2"
                 >
                   <span className="mt-0.5 text-cyan-300">•</span>
-                  <span>{objective}</span>
+                  <span>{objective.description}</span>
                 </li>
               ))}
             </ul>

--- a/code/components/__tests__/ReleaseNotesGenerator.test.tsx
+++ b/code/components/__tests__/ReleaseNotesGenerator.test.tsx
@@ -81,6 +81,7 @@ describe('ReleaseNotesGenerator', () => {
   it('generates release notes and rewards XP', async () => {
     const user = userEvent.setup();
     const addXp = vi.fn();
+    const onDraftGenerated = vi.fn();
     mockedGenerateReleaseNotes.mockResolvedValue('Here are the new release notes!');
 
     render(
@@ -89,6 +90,7 @@ describe('ReleaseNotesGenerator', () => {
         projectTitle="Tamenzut"
         artifacts={baseArtifacts}
         addXp={addXp}
+        onDraftGenerated={onDraftGenerated}
       />,
     );
 
@@ -114,6 +116,7 @@ describe('ReleaseNotesGenerator', () => {
       }),
     );
     expect(addXp).toHaveBeenCalledWith(7);
+    expect(onDraftGenerated).toHaveBeenCalledTimes(1);
   });
 
   it('clears generated notes when switching projects', async () => {

--- a/code/types.ts
+++ b/code/types.ts
@@ -192,12 +192,32 @@ export interface TemplateCategory {
     templates: TemplateEntry[];
 }
 
+export type MilestoneMetric =
+    | 'graph-core'
+    | 'view-engagement'
+    | 'csv-flows'
+    | 'github-import'
+    | 'rich-editors'
+    | 'progression-loops'
+    | 'markdown-export'
+    | 'static-site'
+    | 'release-notes'
+    | 'search-filters'
+    | 'plugin-api'
+    | 'theming-offline';
+
+export interface MilestoneObjective {
+    id: string;
+    description: string;
+    metric?: MilestoneMetric;
+}
+
 export interface Milestone {
     id: string;
     title: string;
     timeline: string;
     focus: string;
-    objectives: string[];
+    objectives: MilestoneObjective[];
 }
 
 export interface AIAssistant {

--- a/code/utils/__tests__/milestoneProgress.test.ts
+++ b/code/utils/__tests__/milestoneProgress.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  evaluateMilestoneProgress,
+  createProjectActivity,
+  ObjectiveStatus,
+} from '../milestoneProgress';
+import {
+  Artifact,
+  ArtifactType,
+  Milestone,
+  Project,
+  ProjectStatus,
+  TaskData,
+  TaskState,
+  UserProfile,
+} from '../../types';
+
+describe('evaluateMilestoneProgress', () => {
+  const project: Project = {
+    id: 'proj-1',
+    ownerId: 'user-1',
+    title: 'Tamenzut',
+    summary: 'High fantasy saga.',
+    status: ProjectStatus.Active,
+    tags: ['fantasy'],
+  };
+
+  const profile: UserProfile = {
+    uid: 'user-1',
+    email: 'user@example.com',
+    displayName: 'Astra Creator',
+    xp: 120,
+    achievementsUnlocked: ['ach-1'],
+    settings: {
+      theme: 'dark',
+      aiTipsEnabled: true,
+    },
+  };
+
+  const artifacts: Artifact[] = [
+    {
+      id: 'art-story',
+      ownerId: 'user-1',
+      projectId: 'proj-1',
+      type: ArtifactType.Story,
+      title: 'Chapter One',
+      summary: 'Opening chapter draft.',
+      status: 'released',
+      tags: ['story'],
+      relations: [{ toId: 'art-task', kind: 'RELATES_TO' }],
+      data: [],
+    },
+    {
+      id: 'art-task',
+      ownerId: 'user-1',
+      projectId: 'proj-1',
+      type: ArtifactType.Task,
+      title: 'Outline Act II',
+      summary: 'Plan the second act beats.',
+      status: 'done',
+      tags: ['planning'],
+      relations: [{ toId: 'art-story', kind: 'SUPPORTS' }],
+      data: { state: TaskState.Done } as TaskData,
+    },
+    {
+      id: 'art-conlang',
+      ownerId: 'user-1',
+      projectId: 'proj-1',
+      type: ArtifactType.Conlang,
+      title: 'Darv Lexicon',
+      summary: 'Foundational vocabulary.',
+      status: 'draft',
+      tags: ['language'],
+      relations: [],
+      data: [],
+    },
+  ];
+
+  const milestones: Milestone[] = [
+    {
+      id: 'm1',
+      title: 'M1',
+      timeline: 'Weeks 1–4',
+      focus: 'Establish foundations.',
+      objectives: [
+        { id: 'core-graph', description: 'Core graph', metric: 'graph-core' },
+        { id: 'view', description: 'Views', metric: 'view-engagement' },
+        { id: 'csv', description: 'CSV flows', metric: 'csv-flows' },
+        { id: 'github', description: 'GitHub import', metric: 'github-import' },
+      ],
+    },
+    {
+      id: 'm2',
+      title: 'M2',
+      timeline: 'Weeks 5–8',
+      focus: 'Level up editors.',
+      objectives: [
+        { id: 'editors', description: 'Rich editors', metric: 'rich-editors' },
+        { id: 'progression', description: 'Progression loop', metric: 'progression-loops' },
+        { id: 'markdown', description: 'Markdown export', metric: 'markdown-export' },
+      ],
+    },
+    {
+      id: 'm3',
+      title: 'M3',
+      timeline: 'Weeks 9–12',
+      focus: 'Ship outward.',
+      objectives: [
+        { id: 'static', description: 'Static site', metric: 'static-site' },
+        { id: 'release', description: 'Release notes', metric: 'release-notes' },
+        { id: 'search', description: 'Search & filters', metric: 'search-filters' },
+      ],
+    },
+  ];
+
+  it('summarises milestone status from artifacts and activity', () => {
+    const activity = createProjectActivity();
+    activity.viewedGraph = true;
+    activity.viewedKanban = true;
+    activity.importedCsv = true;
+    activity.exportedData = true;
+    activity.generatedReleaseNotes = true;
+    activity.usedSearch = true;
+    // leave publishedSite false and usedFilters false to exercise in-progress states
+
+    const [m1, m2, m3] = evaluateMilestoneProgress(milestones, {
+      project,
+      artifacts,
+      profile,
+      activity,
+    });
+
+    const statusFor = (statuses: typeof m1.objectives, id: string): ObjectiveStatus | undefined =>
+      statuses.find((objective) => objective.id === id)?.status;
+
+    expect(statusFor(m1.objectives, 'core-graph')).toBe('complete');
+    expect(statusFor(m1.objectives, 'view')).toBe('complete');
+    expect(statusFor(m1.objectives, 'csv')).toBe('complete');
+    expect(statusFor(m1.objectives, 'github')).toBe('not-started');
+
+    expect(statusFor(m2.objectives, 'editors')).toBe('complete');
+    expect(statusFor(m2.objectives, 'progression')).toBe('complete');
+    expect(statusFor(m2.objectives, 'markdown')).toBe('complete');
+
+    expect(statusFor(m3.objectives, 'static')).toBe('in-progress');
+    expect(statusFor(m3.objectives, 'release')).toBe('complete');
+    expect(statusFor(m3.objectives, 'search')).toBe('in-progress');
+
+    expect(m1.completion).toBeCloseTo(0.75, 2);
+    expect(m2.completion).toBe(1);
+    expect(m3.completion).toBeCloseTo(1 / 3, 2);
+  });
+});

--- a/code/utils/milestoneProgress.ts
+++ b/code/utils/milestoneProgress.ts
@@ -1,0 +1,201 @@
+import {
+  Artifact,
+  ArtifactType,
+  Milestone,
+  MilestoneMetric,
+  MilestoneObjective,
+  Project,
+  TaskData,
+  TaskState,
+  UserProfile,
+} from '../types';
+
+export type ObjectiveStatus = 'not-started' | 'in-progress' | 'complete';
+
+export interface ProjectActivity {
+  viewedGraph: boolean;
+  viewedKanban: boolean;
+  importedCsv: boolean;
+  exportedData: boolean;
+  publishedSite: boolean;
+  generatedReleaseNotes: boolean;
+  githubImported: boolean;
+  usedSearch: boolean;
+  usedFilters: boolean;
+}
+
+export const createProjectActivity = (): ProjectActivity => ({
+  viewedGraph: false,
+  viewedKanban: false,
+  importedCsv: false,
+  exportedData: false,
+  publishedSite: false,
+  generatedReleaseNotes: false,
+  githubImported: false,
+  usedSearch: false,
+  usedFilters: false,
+});
+
+export interface MilestoneObjectiveStatus extends MilestoneObjective {
+  status: ObjectiveStatus;
+  detail: string;
+}
+
+export interface MilestoneProgressOverview {
+  milestone: Milestone;
+  objectives: MilestoneObjectiveStatus[];
+  completion: number;
+}
+
+interface EvaluationContext {
+  project?: Project;
+  artifacts: Artifact[];
+  profile: UserProfile | null;
+  activity: ProjectActivity;
+}
+
+const describeChecklist = (label: string, done: boolean): string => `${label} ${done ? '✔' : '—'}`;
+
+const computeObjectiveStatus = (metric: MilestoneMetric | undefined, context: EvaluationContext): { status: ObjectiveStatus; detail: string } => {
+  const { artifacts, profile, activity } = context;
+
+  switch (metric) {
+    case 'graph-core': {
+      const artifactCount = artifacts.length;
+      const relationCount = artifacts.reduce((total, artifact) => total + artifact.relations.length, 0);
+      if (artifactCount === 0) {
+        return { status: 'not-started', detail: 'No artifacts seeded yet.' };
+      }
+      if (relationCount > 0) {
+        return { status: 'complete', detail: `${relationCount} total links created.` };
+      }
+      return { status: 'in-progress', detail: 'Artifacts captured. Add relations to complete the graph.' };
+    }
+    case 'view-engagement': {
+      const artifactCount = artifacts.length;
+      const sawGraph = activity.viewedGraph;
+      if (artifactCount === 0) {
+        return { status: 'not-started', detail: 'Seed artifacts to explore views.' };
+      }
+      if (artifactCount >= 3 && sawGraph) {
+        return { status: 'complete', detail: `${artifactCount} artifacts seeded and graph view explored.` };
+      }
+      const detail = `${artifactCount} artifacts captured${sawGraph ? '; graph view explored' : '; open the graph view to complete.'}`;
+      return { status: 'in-progress', detail };
+    }
+    case 'csv-flows': {
+      const { importedCsv, exportedData } = activity;
+      if (!importedCsv && !exportedData) {
+        return { status: 'not-started', detail: 'No CSV or TSV activity yet.' };
+      }
+      if (importedCsv && exportedData) {
+        return { status: 'complete', detail: 'CSV import and export both confirmed.' };
+      }
+      return {
+        status: 'in-progress',
+        detail: `${describeChecklist('Import', importedCsv)} · ${describeChecklist('Export', exportedData)}`,
+      };
+    }
+    case 'github-import': {
+      if (activity.githubImported) {
+        return { status: 'complete', detail: 'GitHub artifacts synced into this project.' };
+      }
+      return { status: 'not-started', detail: 'No GitHub repositories imported yet.' };
+    }
+    case 'rich-editors': {
+      const hasConlang = artifacts.some((artifact) => artifact.type === ArtifactType.Conlang);
+      const hasStoryboard = artifacts.some((artifact) => artifact.type === ArtifactType.Story || artifact.type === ArtifactType.Scene);
+      const sawKanban = activity.viewedKanban;
+      const fulfilled = [hasConlang, hasStoryboard, sawKanban].filter(Boolean).length;
+      const status: ObjectiveStatus = fulfilled === 0 ? 'not-started' : fulfilled === 3 ? 'complete' : 'in-progress';
+      const detail = [
+        describeChecklist('Conlang editor', hasConlang),
+        describeChecklist('Storyboard seeds', hasStoryboard),
+        describeChecklist('Kanban view', sawKanban),
+      ].join(' · ');
+      return { status, detail };
+    }
+    case 'progression-loops': {
+      const doneTasks = artifacts.filter((artifact) => artifact.type === ArtifactType.Task).filter((artifact) => {
+        const data = artifact.data as TaskData | undefined;
+        return data?.state === TaskState.Done;
+      }).length;
+      const achievementsUnlocked = profile?.achievementsUnlocked?.length ?? 0;
+      const xp = profile?.xp ?? 0;
+      const hasQuestProgress = doneTasks > 0 || xp >= 50;
+      if (!hasQuestProgress && achievementsUnlocked === 0) {
+        return { status: 'not-started', detail: 'Complete quests or earn achievements to begin the loop.' };
+      }
+      if (hasQuestProgress && achievementsUnlocked > 0) {
+        return { status: 'complete', detail: `${doneTasks} tasks completed · ${achievementsUnlocked} achievements unlocked.` };
+      }
+      return {
+        status: 'in-progress',
+        detail: `${doneTasks} tasks completed · ${achievementsUnlocked} achievements unlocked · ${xp} XP earned.`,
+      };
+    }
+    case 'markdown-export': {
+      if (activity.exportedData) {
+        return { status: 'complete', detail: 'Exported data ready for markdown bundling.' };
+      }
+      if (activity.importedCsv) {
+        return { status: 'in-progress', detail: 'CSV imports prepped—trigger an export to finish.' };
+      }
+      return { status: 'not-started', detail: 'No export actions recorded yet.' };
+    }
+    case 'static-site': {
+      if (activity.publishedSite) {
+        return { status: 'complete', detail: 'Static export triggered for this project.' };
+      }
+      return { status: 'in-progress', detail: 'Use “Publish Site” to generate a static bundle.' };
+    }
+    case 'release-notes': {
+      if (activity.generatedReleaseNotes) {
+        return { status: 'complete', detail: 'AI-powered release notes drafted.' };
+      }
+      return { status: 'not-started', detail: 'Generate release notes to track launch readiness.' };
+    }
+    case 'search-filters': {
+      const { usedSearch, usedFilters } = activity;
+      if (usedSearch && usedFilters) {
+        return { status: 'complete', detail: 'Search and advanced filters explored.' };
+      }
+      if (usedSearch || usedFilters) {
+        return {
+          status: 'in-progress',
+          detail: `${describeChecklist('Search', usedSearch)} · ${describeChecklist('Filters', usedFilters)}`,
+        };
+      }
+      return { status: 'not-started', detail: 'Try the search bar or filters to surface artifacts faster.' };
+    }
+    case 'plugin-api':
+    case 'theming-offline':
+      return { status: 'not-started', detail: 'Roadmap item — work begins in later phases.' };
+    default:
+      return { status: 'not-started', detail: 'Status tracking not yet instrumented.' };
+  }
+};
+
+export const evaluateMilestoneProgress = (
+  milestones: Milestone[],
+  context: EvaluationContext,
+): MilestoneProgressOverview[] => {
+  return milestones.map((milestone) => {
+    const objectives = milestone.objectives.map((objective) => {
+      const evaluation = computeObjectiveStatus(objective.metric, context);
+      return {
+        ...objective,
+        ...evaluation,
+      };
+    });
+
+    const completedObjectives = objectives.filter((objective) => objective.status === 'complete').length;
+    const completion = objectives.length > 0 ? completedObjectives / objectives.length : 0;
+
+    return {
+      milestone,
+      objectives,
+      completion,
+    };
+  });
+};


### PR DESCRIPTION
## Summary
- add milestone progress evaluation utilities and a dashboard tracker component
- instrument project activity updates across capture, imports, exports, and release drafting to feed milestone status
- extend release notes handling and tests to confirm progress signals are emitted when drafts are generated

## Testing
- CI=1 npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690173f3063083288b4844f4a5c1e31a