### PR TITLE
Reset release notes settings when switching projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A playful, gamified personal knowledge system for organizing web comics, wikis, 
 - [x] Add reusable project templates (comic, conlang, game design, wiki) that hydrate dashboards, tables, and starter artifacts.
 - [x] Clarify the copy and badges that differentiate "Project Templates" (multi-artifact kits) from the exploratory "Template Library" surface.
 - [x] Link each project template to the underlying template-library categories (and vice versa) so the hierarchy is obvious while keeping both entry points.
-- [ ] Ensure changing projects resets AI-generated draft release notes so context stays accurate.
+- [x] Ensure changing projects resets AI-generated draft release notes so context stays accurate.
 
 ### Phase 2 — Grow Projects (Weeks 5‑8)
 - [ ] Expand the dashboard with Layer 2 views: Kanban lanes, milestone tracker, table editor, and graph glance showing artifact relationships.

--- a/code/components/ReleaseNotesGenerator.tsx
+++ b/code/components/ReleaseNotesGenerator.tsx
@@ -86,6 +86,8 @@ const ReleaseNotesGenerator: React.FC<ReleaseNotesGeneratorProps> = ({
   }, [autoHighlights, hasEditedHighlights]);
 
   useEffect(() => {
+    setTone('playful');
+    setAudience('collaborators');
     setGeneratedNotes('');
     setNotes('');
     setError(null);

--- a/code/components/__tests__/ReleaseNotesGenerator.test.tsx
+++ b/code/components/__tests__/ReleaseNotesGenerator.test.tsx
@@ -160,6 +160,47 @@ describe('ReleaseNotesGenerator', () => {
     });
   });
 
+  it('resets configuration when switching projects', async () => {
+    const user = userEvent.setup();
+    const addXp = vi.fn();
+
+    const { rerender } = render(
+      <ReleaseNotesGenerator
+        projectId="project-tamenzut"
+        projectTitle="Tamenzut"
+        artifacts={baseArtifacts}
+        addXp={addXp}
+      />, 
+    );
+
+    const toneSelect = screen.getByLabelText(/Tone/i) as HTMLSelectElement;
+    const audienceSelect = screen.getByLabelText(/Audience/i) as HTMLSelectElement;
+    const notesField = screen.getByLabelText(/Optional calls-to-action/i) as HTMLTextAreaElement;
+
+    await user.selectOptions(toneSelect, 'formal');
+    await user.selectOptions(audienceSelect, 'players');
+    await user.type(notesField, 'Join us for the next launch!');
+
+    expect(toneSelect.value).toBe('formal');
+    expect(audienceSelect.value).toBe('players');
+    expect(notesField.value).toContain('Join us for the next launch!');
+
+    rerender(
+      <ReleaseNotesGenerator
+        projectId="project-steamweave"
+        projectTitle="Steamweave"
+        artifacts={baseArtifacts}
+        addXp={addXp}
+      />, 
+    );
+
+    await waitFor(() => {
+      expect((screen.getByLabelText(/Tone/i) as HTMLSelectElement).value).toBe('playful');
+    });
+    expect((screen.getByLabelText(/Audience/i) as HTMLSelectElement).value).toBe('collaborators');
+    expect((screen.getByLabelText(/Optional calls-to-action/i) as HTMLTextAreaElement).value).toBe('');
+  });
+
   it('retains manual edits when new artifact data arrives', async () => {
     const user = userEvent.setup();
     const addXp = vi.fn();


### PR DESCRIPTION
## Summary
- reset the Release Bard tone, audience, and note drafts when the active project changes so AI notes always reflect the current world
- add a regression test that verifies configuration state resets during project switches
- mark the roadmap item for resetting draft release notes as complete in the README

## Testing
- npm run test -- ReleaseNotesGenerator
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6901741b45b48328aed5c8902f30d89d