### PR TITLE
Fix App hook order guard to prevent React warning

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1027,16 +1027,6 @@ export default function App() {
     updateProfile({ questlinesClaimed: [questlineId] });
   }, [profile, addXp, updateProfile]);
 
-  if (!profile) {
-    return null;
-  }
-
-  const xpProgress = profile.xp % 100;
-  const level = Math.floor(profile.xp / 100) + 1;
-  const isViewingOwnWorkspace = !selectedProject || selectedProject.ownerId === profile.uid;
-  const featuredAssistant = aiAssistants[0];
-  const upcomingMilestone = milestoneRoadmap[0];
-
   const handleResetFilters = () => {
     setArtifactTypeFilter('ALL');
     setStatusFilter('ALL');


### PR DESCRIPTION
## Summary
- move App view mode/export callbacks before the profile guard so hooks fire in a consistent order
- remove the duplicate guard and derived profile calculations that were defined twice

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6902369b27ec83288efa09a9be28414f