### PR TITLE
Fix unused id variables when persisting updates

### DIFF
--- a/code/contexts/UserDataContext.tsx
+++ b/code/contexts/UserDataContext.tsx
@@ -198,7 +198,8 @@ const persistProjectsDiff = async (previous: Project[], next: Project[]) => {
     }
 
     if (!areProjectsEqual(existing, project)) {
-      const { id: _id, ...rest } = project;
+      const rest = { ...project };
+      delete rest.id;
       batch.set(ref, {
         ...sanitizeForFirestore(rest),
         updatedAt: serverTimestamp(),
@@ -239,7 +240,8 @@ const persistArtifactsDiff = async (previous: Artifact[], next: Artifact[]) => {
     }
 
     if (!areArtifactsEqual(existing, artifact)) {
-      const { id: _id, ...rest } = artifact;
+      const rest = { ...artifact };
+      delete rest.id;
       batch.set(ref, {
         ...sanitizeForFirestore(rest),
         updatedAt: serverTimestamp(),


### PR DESCRIPTION
## Summary
- avoid unused variable lint violations in `persistProjectsDiff` and `persistArtifactsDiff`
- create sanitized copies without the `id` field before writing to Firestore

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_69023842d8bc8328930fa6ab28e5c750