### PR TITLE
Fix modal positioning by rendering via portal

### DIFF
--- a/code/components/Modal.tsx
+++ b/code/components/Modal.tsx
@@ -1,5 +1,6 @@
 
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { XMarkIcon } from './Icons';
 
 interface ModalProps {
@@ -47,13 +48,32 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
     };
   }, [isOpen, onClose]);
 
-  if (!isOpen) {
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen || !isClient) {
+      return;
+    }
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    return () => {
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [isClient, isOpen]);
+
+  if (!isOpen || !isClient) {
     return null;
   }
 
-  return (
+  const modalContent = (
     <div
-      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex justify-center items-center z-50 animate-fade-in relative"
+      className="fixed inset-0 bg-black/70 backdrop-blur-sm flex justify-center items-center z-50 animate-fade-in"
       role="dialog"
       aria-modal="true"
       aria-labelledby="modal-title"
@@ -79,6 +99,8 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
       </div>
     </div>
   );
+
+  return createPortal(modalContent, document.body);
 };
 
 export default Modal;


### PR DESCRIPTION
## Summary
- render the shared modal component through a React portal anchored to document.body
- block page scrolling while the modal is open to keep overlays focused

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_690238823b088328820350b84fdb903a