### PR TITLE
Add toast notifications for project template application

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -51,6 +51,7 @@ import GitHubImportPanel from './components/GitHubImportPanel';
 import SecondaryInsightsPanel from './components/SecondaryInsightsPanel';
 import MilestoneTracker from './components/MilestoneTracker';
 import { createProjectActivity, evaluateMilestoneProgress, MilestoneProgressOverview, ProjectActivity } from './utils/milestoneProgress';
+import { useToast } from './components/ToastProvider';
 
 const dailyQuests: Quest[] = [
     { id: 'q1', title: 'First Seed', description: 'Create at least one new artifact.', isCompleted: (artifacts) => artifacts.length > 7, xp: 5 },
@@ -641,6 +642,7 @@ const ArtifactListItem: React.FC<{ artifact: Artifact; onSelect: (id: string) =>
 export default function App() {
   const { projects, setProjects, artifacts, setArtifacts, profile, addXp, updateProfile } = useUserData();
   const { signOutUser, getIdToken, isGuestMode } = useAuth();
+  const { showToast } = useToast();
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [selectedArtifactId, setSelectedArtifactId] = useState<string | null>(null);
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
@@ -866,9 +868,16 @@ export default function App() {
       setArtifacts(prev => [...prev, ...newArtifacts]);
       addXp(newArtifacts.length * 5);
       setSelectedArtifactId(newArtifacts[0].id);
-      alert(`Added ${newArtifacts.length} starter artifact${newArtifacts.length > 1 ? 's' : ''} from the ${template.name} template.`);
+      showToast({
+        title: 'Template applied',
+        description: `Added ${newArtifacts.length} starter artifact${newArtifacts.length > 1 ? 's' : ''} from the ${template.name} template.`,
+        variant: 'success',
+      });
     } else {
-      alert('All of the template\'s starter artifacts already exist in this project.');
+      showToast({
+        title: 'Nothing new to add',
+        description: "All of the template's starter artifacts already exist in this project.",
+      });
     }
 
     if (template.projectTags.length > 0) {
@@ -888,7 +897,7 @@ export default function App() {
         return changed ? next : prev;
       });
     }
-  }, [profile, selectedProjectId, artifacts, setArtifacts, addXp, setProjects]);
+  }, [profile, selectedProjectId, artifacts, setArtifacts, addXp, setProjects, showToast]);
 
   const handleImportClick = () => {
     fileInputRef.current?.click();

--- a/code/components/ToastProvider.tsx
+++ b/code/components/ToastProvider.tsx
@@ -1,0 +1,100 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+export type ToastVariant = 'info' | 'success' | 'error';
+
+interface ShowToastOptions {
+  title?: string;
+  description: string;
+  variant?: ToastVariant;
+  duration?: number;
+}
+
+interface ToastRecord extends ShowToastOptions {
+  id: number;
+}
+
+interface ToastContextValue {
+  showToast: (options: ShowToastOptions) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | undefined>(undefined);
+
+export const useToast = (): ToastContextValue => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};
+
+const variantClasses: Record<ToastVariant, string> = {
+  info: 'bg-slate-900/80 border border-slate-700 text-slate-100 shadow-lg shadow-slate-950/40',
+  success: 'bg-emerald-900/80 border border-emerald-700 text-emerald-100 shadow-lg shadow-emerald-950/30',
+  error: 'bg-rose-950/85 border border-rose-800 text-rose-100 shadow-lg shadow-rose-950/30',
+};
+
+export const ToastProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [toasts, setToasts] = useState<ToastRecord[]>([]);
+  const timeoutRegistry = useRef(new Map<number, number>());
+
+  const removeToast = useCallback((id: number) => {
+    setToasts(prev => prev.filter(toast => toast.id !== id));
+    const timeoutId = timeoutRegistry.current.get(id);
+    if (timeoutId !== undefined) {
+      window.clearTimeout(timeoutId);
+      timeoutRegistry.current.delete(id);
+    }
+  }, []);
+
+  const showToast = useCallback(
+    ({ title, description, variant = 'info', duration = 4000 }: ShowToastOptions) => {
+      const id = Date.now() + Math.random();
+      setToasts(prev => [...prev, { id, title, description, variant, duration }]);
+      const timeoutId = window.setTimeout(() => removeToast(id), duration);
+      timeoutRegistry.current.set(id, timeoutId);
+    },
+    [removeToast],
+  );
+
+  useEffect(() => {
+    return () => {
+      timeoutRegistry.current.forEach(timeoutId => window.clearTimeout(timeoutId));
+      timeoutRegistry.current.clear();
+    };
+  }, []);
+
+  const contextValue = useMemo(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={contextValue}>
+      {children}
+      <div className="pointer-events-none fixed inset-x-0 top-4 z-50 flex flex-col items-center gap-3 px-4">
+        {toasts.map(({ id, title, description, variant }) => (
+          <div
+            key={id}
+            className={`pointer-events-auto w-full max-w-sm rounded-lg px-4 py-3 ${variantClasses[variant]}`}
+            role="status"
+            aria-live="polite"
+          >
+            <div className="flex items-start gap-3">
+              <div className="flex-1">
+                {title ? <p className="text-sm font-semibold leading-tight">{title}</p> : null}
+                <p className="text-sm leading-snug">{description}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => removeToast(id)}
+                className="rounded-md p-1 text-xs uppercase tracking-wide text-current transition hover:bg-white/10"
+                aria-label="Dismiss notification"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+};
+
+export default ToastProvider;

--- a/code/index.tsx
+++ b/code/index.tsx
@@ -6,6 +6,7 @@ import './services/firebaseApp';
 import { AuthProvider } from './contexts/AuthContext';
 import { UserDataProvider } from './contexts/UserDataContext';
 import AuthGate from './components/AuthGate';
+import { ToastProvider } from './components/ToastProvider';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {
@@ -17,9 +18,11 @@ root.render(
   <React.StrictMode>
     <AuthProvider>
       <UserDataProvider>
-        <AuthGate>
-          <App />
-        </AuthGate>
+        <ToastProvider>
+          <AuthGate>
+            <App />
+          </AuthGate>
+        </ToastProvider>
       </UserDataProvider>
     </AuthProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- introduce a reusable ToastProvider component for in-app notifications
- wrap the app root with the toast provider so notifications are available throughout the UI
- switch project template application feedback from blocking alerts to styled toast messages

## Testing
- npm run build
- npm run test:e2e *(fails: playwright could not find the “New Seed” button during the smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_6902412db5b48328b9a3e8dbbb7a968f