### PR TITLE
Refactor data layer to use API-driven context

### DIFF
--- a/code/components/ArtifactDetail.tsx
+++ b/code/components/ArtifactDetail.tsx
@@ -8,7 +8,7 @@ import { SparklesIcon, Spinner, LinkIcon, PlusIcon, ArrowDownTrayIcon, XMarkIcon
 interface ArtifactDetailProps {
   artifact: Artifact;
   projectArtifacts: Artifact[];
-  onUpdateArtifact: (updatedArtifact: Artifact) => void;
+  onUpdateArtifact: (artifactId: string, updates: Partial<Artifact>) => void;
   onAddRelation: (fromId: string, toId: string, kind: string) => void;
   onRemoveRelation: (fromId: string, relationIndex: number) => void;
   addXp: (amount: number) => void;
@@ -51,7 +51,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
     setExpandError(null);
     try {
       const newSummary = await expandSummary(artifact);
-      onUpdateArtifact({ ...artifact, summary: newSummary });
+      onUpdateArtifact(artifact.id, { summary: newSummary });
       setEditableSummary(newSummary);
       addXp(6); // XP Source: Lore Weaver assist (+6)
     } catch (e) {
@@ -64,7 +64,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
   const handleStatusChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const newStatus = event.target.value;
     if (newStatus && newStatus !== artifact.status) {
-      onUpdateArtifact({ ...artifact, status: newStatus });
+      onUpdateArtifact(artifact.id, { status: newStatus });
     }
   };
 
@@ -83,7 +83,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
   };
 
   const handleSaveSummary = () => {
-    onUpdateArtifact({ ...artifact, summary: editableSummary });
+    onUpdateArtifact(artifact.id, { summary: editableSummary });
     setIsEditingSummary(false);
   };
 
@@ -100,7 +100,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
       setTagInput('');
       return;
     }
-    onUpdateArtifact({ ...artifact, tags: [...artifact.tags, newTag] });
+    onUpdateArtifact(artifact.id, { tags: [...artifact.tags, newTag] });
     setTagInput('');
   };
 
@@ -112,7 +112,9 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
   };
 
   const handleRemoveTag = (tagToRemove: string) => {
-    onUpdateArtifact({ ...artifact, tags: artifact.tags.filter((tag) => tag !== tagToRemove) });
+    onUpdateArtifact(artifact.id, {
+      tags: artifact.tags.filter((tag) => tag !== tagToRemove),
+    });
   };
 
   const availableTargets = projectArtifacts.filter((a) => a.id !== artifact.id && !artifact.relations.some((r) => r.toId === a.id));

--- a/code/components/GitHubImportPanel.tsx
+++ b/code/components/GitHubImportPanel.tsx
@@ -7,7 +7,7 @@ interface GitHubImportPanelProps {
   projectId: string;
   ownerId: string;
   existingArtifacts: Artifact[];
-  onArtifactsImported: (artifacts: Artifact[]) => void;
+  onArtifactsImported: (artifacts: Artifact[]) => Promise<void> | void;
   addXp: (amount: number) => void;
 }
 
@@ -147,7 +147,7 @@ const GitHubImportPanel: React.FC<GitHubImportPanelProps> = ({ projectId, ownerI
         return;
       }
 
-      onArtifactsImported(newArtifacts);
+      await onArtifactsImported(newArtifacts);
       const xpAward = Math.min(25, Math.max(8, newArtifacts.length * 3));
       addXp(xpAward);
       setImportSummary(`Imported ${newArtifacts.length} artifact${newArtifacts.length === 1 ? '' : 's'} from GitHub (+${xpAward} XP).`);

--- a/code/components/ProjectOverview.tsx
+++ b/code/components/ProjectOverview.tsx
@@ -5,7 +5,7 @@ import { TagIcon, XMarkIcon } from './Icons';
 
 interface ProjectOverviewProps {
   project: Project;
-  onUpdateProject: (projectId: string, updater: (project: Project) => Project) => void;
+  onUpdateProject: (projectId: string, updates: Partial<Project>) => void;
 }
 
 const statusOrder: ProjectStatus[] = [
@@ -35,7 +35,7 @@ const ProjectOverview: React.FC<ProjectOverviewProps> = ({ project, onUpdateProj
   const handleStatusChange = (event: React.ChangeEvent<HTMLSelectElement>) => {
     const nextStatus = event.target.value as ProjectStatus;
     if (nextStatus === project.status) return;
-    onUpdateProject(project.id, (current) => ({ ...current, status: nextStatus }));
+    onUpdateProject(project.id, { status: nextStatus });
   };
 
   const handleSummarySubmit = (event: React.FormEvent<HTMLFormElement>) => {
@@ -45,7 +45,7 @@ const ProjectOverview: React.FC<ProjectOverviewProps> = ({ project, onUpdateProj
       setSummaryError('Summary cannot be empty.');
       return;
     }
-    onUpdateProject(project.id, (current) => ({ ...current, summary: trimmed }));
+    onUpdateProject(project.id, { summary: trimmed });
     setSummaryError(null);
     setIsEditingSummary(false);
   };
@@ -63,24 +63,21 @@ const ProjectOverview: React.FC<ProjectOverviewProps> = ({ project, onUpdateProj
       return;
     }
 
-    onUpdateProject(project.id, (current) => {
-      const exists = current.tags.some((tag) => tag.toLowerCase() === trimmed.toLowerCase());
-      if (exists) {
-        setTagError('That tag is already attached to this project.');
-        return current;
-      }
-      return { ...current, tags: [...current.tags, trimmed] };
-    });
+    const exists = project.tags.some((tag) => tag.toLowerCase() === trimmed.toLowerCase());
+    if (exists) {
+      setTagError('That tag is already attached to this project.');
+      return;
+    }
 
+    onUpdateProject(project.id, { tags: [...project.tags, trimmed] });
     setTagInput('');
     setTagError(null);
   };
 
   const handleRemoveTag = (tagToRemove: string) => {
-    onUpdateProject(project.id, (current) => ({
-      ...current,
-      tags: current.tags.filter((tag) => tag !== tagToRemove),
-    }));
+    onUpdateProject(project.id, {
+      tags: project.tags.filter((tag) => tag !== tagToRemove),
+    });
   };
 
   const handleTagKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/code/services/dataApi.ts
+++ b/code/services/dataApi.ts
@@ -1,4 +1,4 @@
-import type { Artifact, ConlangLexeme } from '../types';
+import type { Artifact, ConlangLexeme, Project, UserProfile } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_DATA_API_BASE_URL?.replace(/\/$/, '') ?? '';
 
@@ -13,6 +13,178 @@ const withAuth = async (token: string | null, init: RequestInit = {}): Promise<R
   headers.set('Authorization', `Bearer ${token}`);
 
   return { ...init, headers };
+};
+
+const parseJson = async <T>(response: Response): Promise<T> => {
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(message || `Data API request failed with status ${response.status}.`);
+  }
+  return (await response.json()) as T;
+};
+
+const sendJson = async <T>(
+  token: string | null,
+  path: string,
+  init: RequestInit & { body?: unknown },
+): Promise<T> => {
+  if (!isDataApiConfigured) {
+    throw new Error('Data API is not configured.');
+  }
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...(await withAuth(token, {
+      ...init,
+      headers: {
+        'Content-Type': 'application/json',
+        ...(init.headers ?? {}),
+      },
+      body: init.body !== undefined ? JSON.stringify(init.body) : undefined,
+    })),
+  });
+
+  return parseJson<T>(response);
+};
+
+export interface ProjectListResponse {
+  projects: Project[];
+  nextPageToken?: string;
+}
+
+export interface ArtifactListResponse {
+  artifacts: Artifact[];
+  nextPageToken?: string;
+}
+
+export type ArtifactDraft = {
+  id?: string;
+  type: Artifact['type'];
+  title: string;
+  summary?: string;
+  status?: string;
+  tags?: string[];
+  relations?: Artifact['relations'];
+  data?: Artifact['data'];
+};
+
+export const fetchProfile = async (token: string | null): Promise<UserProfile> =>
+  sendJson<UserProfile>(token, '/api/profile', { method: 'GET' });
+
+export const updateProfileViaApi = async (
+  token: string | null,
+  update: Partial<Pick<UserProfile, 'displayName' | 'photoURL' | 'achievementsUnlocked' | 'questlinesClaimed'>> & {
+    settings?: Partial<UserProfile['settings']>;
+  },
+): Promise<UserProfile> =>
+  sendJson<UserProfile>(token, '/api/profile', { method: 'PATCH', body: update });
+
+export const incrementProfileXp = async (token: string | null, amount: number): Promise<UserProfile> =>
+  sendJson<UserProfile>(token, '/api/profile/xp', { method: 'POST', body: { amount } });
+
+export const fetchProjects = async (
+  token: string | null,
+  params: { pageSize?: number; pageToken?: string } = {},
+): Promise<ProjectListResponse> => {
+  if (!isDataApiConfigured) {
+    throw new Error('Data API is not configured.');
+  }
+
+  const query = new URLSearchParams();
+  if (params.pageSize) {
+    query.set('pageSize', String(params.pageSize));
+  }
+  if (params.pageToken) {
+    query.set('pageToken', params.pageToken);
+  }
+  const qs = query.toString();
+  const response = await fetch(`${API_BASE_URL}/api/projects${qs ? `?${qs}` : ''}`, {
+    method: 'GET',
+    ...(await withAuth(token)),
+  });
+  return parseJson<ProjectListResponse>(response);
+};
+
+export const createProjectViaApi = async (
+  token: string | null,
+  project: { title: string; summary?: string; status?: string; tags?: string[] },
+): Promise<Project> => sendJson<Project>(token, '/api/projects', { method: 'POST', body: project });
+
+export const updateProjectViaApi = async (
+  token: string | null,
+  projectId: string,
+  updates: Partial<Pick<Project, 'title' | 'summary' | 'status' | 'tags'>>,
+): Promise<Project> => sendJson<Project>(token, `/api/projects/${projectId}`, { method: 'PATCH', body: updates });
+
+export const deleteProjectViaApi = async (token: string | null, projectId: string): Promise<void> => {
+  if (!isDataApiConfigured) {
+    throw new Error('Data API is not configured.');
+  }
+
+  const response = await fetch(`${API_BASE_URL}/api/projects/${projectId}`, {
+    method: 'DELETE',
+    ...(await withAuth(token)),
+  });
+
+  if (!response.ok && response.status !== 204) {
+    const message = await response.text();
+    throw new Error(message || 'Failed to delete project.');
+  }
+};
+
+export const fetchProjectArtifacts = async (
+  token: string | null,
+  projectId: string,
+  params: { pageSize?: number; pageToken?: string } = {},
+): Promise<ArtifactListResponse> => {
+  if (!isDataApiConfigured) {
+    throw new Error('Data API is not configured.');
+  }
+
+  const query = new URLSearchParams();
+  if (params.pageSize) {
+    query.set('pageSize', String(params.pageSize));
+  }
+  if (params.pageToken) {
+    query.set('pageToken', params.pageToken);
+  }
+  const qs = query.toString();
+  const response = await fetch(`${API_BASE_URL}/api/projects/${projectId}/artifacts${qs ? `?${qs}` : ''}`, {
+    method: 'GET',
+    ...(await withAuth(token)),
+  });
+  return parseJson<ArtifactListResponse>(response);
+};
+
+export const createArtifactsViaApi = async (
+  token: string | null,
+  projectId: string,
+  artifacts: ArtifactDraft[],
+): Promise<Artifact[]> =>
+  sendJson<{ artifacts: Artifact[] }>(token, `/api/projects/${projectId}/artifacts`, {
+    method: 'POST',
+    body: { artifacts },
+  }).then((payload) => payload.artifacts);
+
+export const updateArtifactViaApi = async (
+  token: string | null,
+  artifactId: string,
+  updates: Partial<Pick<Artifact, 'title' | 'summary' | 'status' | 'tags' | 'relations' | 'data'>>,
+): Promise<Artifact> => sendJson<Artifact>(token, `/api/artifacts/${artifactId}`, { method: 'PATCH', body: updates });
+
+export const deleteArtifactViaApi = async (token: string | null, artifactId: string): Promise<void> => {
+  if (!isDataApiConfigured) {
+    throw new Error('Data API is not configured.');
+  }
+
+  const response = await fetch(`${API_BASE_URL}/api/artifacts/${artifactId}`, {
+    method: 'DELETE',
+    ...(await withAuth(token)),
+  });
+
+  if (!response.ok && response.status !== 204) {
+    const message = await response.text();
+    throw new Error(message || 'Failed to delete artifact.');
+  }
 };
 
 export const importArtifactsViaApi = async (

--- a/server/src/middleware/authenticate.ts
+++ b/server/src/middleware/authenticate.ts
@@ -5,6 +5,8 @@ export interface AuthenticatedRequest extends Request {
   user?: {
     uid: string;
     email?: string;
+    displayName?: string;
+    photoURL?: string;
   };
 }
 
@@ -21,7 +23,12 @@ export const authenticate = async (req: AuthenticatedRequest, res: Response, nex
     }
 
     const decoded = await auth.verifyIdToken(token);
-    req.user = { uid: decoded.uid, email: decoded.email ?? undefined };
+    req.user = {
+      uid: decoded.uid,
+      email: decoded.email ?? undefined,
+      displayName: decoded.name ?? undefined,
+      photoURL: decoded.picture ?? undefined,
+    };
     next();
   } catch (error) {
     console.error('Authentication failed', error);

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -37,3 +37,24 @@ export interface ConlangLexeme {
   etymology?: string;
   tags?: string[];
 }
+
+export interface UserSettings {
+  theme: 'system' | 'light' | 'dark';
+  aiTipsEnabled: boolean;
+}
+
+export interface UserProfile {
+  uid: string;
+  email: string;
+  displayName: string;
+  photoURL?: string;
+  xp: number;
+  streakCount: number;
+  bestStreak: number;
+  lastActiveDate?: string;
+  achievementsUnlocked: string[];
+  questlinesClaimed: string[];
+  settings: UserSettings;
+  createdAt?: string;
+  updatedAt?: string;
+}


### PR DESCRIPTION
## Summary
- rework UserDataContext to hydrate and mutate workspace data through the REST API with pagination helpers
- update App flows and related components to call the new context actions for project and artifact CRUD and imports
- expand the data API client and backend to expose profile/xp endpoints and per-entity CRUD routes used by the frontend

## Testing
- npm run build
- npm run test:e2e *(fails: missing Playwright browsers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_69023f2ce03c8328bb13e527613dac8f