### PR TITLE
Add collapsible toggles to project template and milestone panels

### DIFF
--- a/code/components/MilestoneTracker.tsx
+++ b/code/components/MilestoneTracker.tsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { MilestoneProgressOverview, ObjectiveStatus } from '../utils/milestoneProgress';
-import { FlagIcon, SparklesIcon, CheckCircleIcon, XMarkIcon } from './Icons';
+import { FlagIcon, SparklesIcon, CheckCircleIcon, XMarkIcon, ChevronDownIcon } from './Icons';
+import Zippy from './Zippy';
 
 interface MilestoneTrackerProps {
   items: MilestoneProgressOverview[];
@@ -33,19 +34,33 @@ const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({ items }) => {
     return null;
   }
 
+  const [isTrackerOpen, setIsTrackerOpen] = useState(true);
+
   return (
     <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
-      <header className="flex items-center gap-3">
-        <FlagIcon className="w-5 h-5 text-cyan-400" />
-        <div>
-          <h3 className="text-lg font-semibold text-slate-100">Milestone tracker</h3>
-          <p className="text-sm text-slate-400">
-            Layer-two progress signals show how close this project is to each roadmap milestone.
-          </p>
+      <header className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <FlagIcon className="w-5 h-5 text-cyan-400" />
+          <div>
+            <h3 className="text-lg font-semibold text-slate-100">Milestone tracker</h3>
+            <p className="text-sm text-slate-400">
+              Layer-two progress signals show how close this project is to each roadmap milestone.
+            </p>
+          </div>
         </div>
+        <button
+          type="button"
+          onClick={() => setIsTrackerOpen((previous) => !previous)}
+          className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-slate-300"
+          aria-expanded={isTrackerOpen}
+          aria-controls="milestone-tracker-content"
+        >
+          {isTrackerOpen ? 'Hide milestones' : 'Show milestones'}
+          <ChevronDownIcon className={`w-4 h-4 text-slate-400 transition-transform ${isTrackerOpen ? 'rotate-180' : ''}`} />
+        </button>
       </header>
 
-      <div className="space-y-5">
+      <Zippy isOpen={isTrackerOpen} id="milestone-tracker-content" className="space-y-5">
         {items.map(({ milestone, objectives, completion }) => {
           const percent = Math.round(completion * 100);
 
@@ -95,7 +110,7 @@ const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({ items }) => {
             </article>
           );
         })}
-      </div>
+      </Zippy>
     </section>
   );
 };

--- a/code/components/ProjectTemplatePicker.tsx
+++ b/code/components/ProjectTemplatePicker.tsx
@@ -1,6 +1,7 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { ProjectTemplate, TemplateCategory } from '../types';
-import { FolderPlusIcon, SparklesIcon } from './Icons';
+import { ChevronDownIcon, FolderPlusIcon, SparklesIcon } from './Icons';
+import Zippy from './Zippy';
 
 interface ProjectTemplatePickerProps {
   templates: ProjectTemplate[];
@@ -17,6 +18,7 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
   onApplyTemplate,
   isApplyDisabled = false,
 }) => {
+  const [isPickerOpen, setIsPickerOpen] = useState(true);
   const categoryIndex = useMemo(() => {
     const index = new Map<string, TemplateCategory>();
     categories.forEach((category) => {
@@ -120,9 +122,23 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
             <SparklesIcon className="w-5 h-5 text-cyan-400" />
             Project Templates
           </div>
-          <span className="text-[10px] font-semibold uppercase tracking-wide text-cyan-200 bg-cyan-900/40 border border-cyan-700/50 rounded-full px-3 py-1">
-            Multi-artifact kit
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-cyan-200 bg-cyan-900/40 border border-cyan-700/50 rounded-full px-3 py-1">
+              Multi-artifact kit
+            </span>
+            <button
+              type="button"
+              onClick={() => setIsPickerOpen((previous) => !previous)}
+              className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-slate-300"
+              aria-expanded={isPickerOpen}
+              aria-controls="project-templates-content"
+            >
+              {isPickerOpen ? 'Hide kits' : 'Show kits'}
+              <ChevronDownIcon
+                className={`w-4 h-4 text-slate-400 transition-transform ${isPickerOpen ? 'rotate-180' : ''}`}
+              />
+            </button>
+          </div>
         </div>
         <p className="text-sm text-slate-400">
           Hydrate an entire project with dashboards, quests, and starter artifacts in one click. Apply a kit to fill gaps without overwriting the custom work you have already done.
@@ -132,23 +148,28 @@ const ProjectTemplatePicker: React.FC<ProjectTemplatePickerProps> = ({
         </p>
       </header>
 
-      {recommended.length > 0 && (
-        <div className="space-y-4">
-          <div className="text-xs font-semibold text-cyan-300 uppercase tracking-wide">Tailored for {activeProjectTitle}</div>
+      <Zippy isOpen={isPickerOpen} id="project-templates-content" className="space-y-6">
+        {recommended.length > 0 && (
           <div className="space-y-4">
-            {recommended.map((template) => renderTemplateCard(template, true))}
+            <div className="text-xs font-semibold text-cyan-300 uppercase tracking-wide">Tailored for {activeProjectTitle}</div>
+            <div className="space-y-4">
+              {recommended.map((template) => renderTemplateCard(template, true))}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {recommended.length > 0 && (
+            <div className="text-xs font-semibold text-slate-400 uppercase tracking-wide">More kits</div>
+          )}
+          <div className="space-y-4">
+            {others.map((template) => renderTemplateCard(template, false))}
+            {recommended.length === 0 && others.length === 0 && (
+              <p className="text-sm text-slate-500">No project templates match that search just yet. Try a different keyword.</p>
+            )}
           </div>
         </div>
-      )}
-
-      <div className="space-y-4">
-        {recommended.length > 0 && (
-          <div className="text-xs font-semibold text-slate-400 uppercase tracking-wide">More kits</div>
-        )}
-        <div className="space-y-4">
-          {others.map((template) => renderTemplateCard(template, false))}
-        </div>
-      </div>
+      </Zippy>
     </section>
   );
 };

--- a/code/components/TemplateGallery.tsx
+++ b/code/components/TemplateGallery.tsx
@@ -11,6 +11,7 @@ interface TemplateGalleryProps {
 
 const TemplateGallery: React.FC<TemplateGalleryProps> = ({ categories, projectTemplates, activeProjectTitle }) => {
   const [searchTerm, setSearchTerm] = useState('');
+  const [isLibraryOpen, setIsLibraryOpen] = useState(true);
 
   const projectTemplateIndex = useMemo(() => {
     const index = new Map<string, ProjectTemplate>();
@@ -161,9 +162,23 @@ const TemplateGallery: React.FC<TemplateGalleryProps> = ({ categories, projectTe
             <SparklesIcon className="w-5 h-5 text-cyan-400" />
             Template Library
           </div>
-          <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-200 bg-amber-900/30 border border-amber-700/50 rounded-full px-3 py-1">
-            Artifact blueprints
-          </span>
+          <div className="flex items-center gap-2">
+            <span className="text-[10px] font-semibold uppercase tracking-wide text-amber-200 bg-amber-900/30 border border-amber-700/50 rounded-full px-3 py-1">
+              Artifact blueprints
+            </span>
+            <button
+              type="button"
+              onClick={() => setIsLibraryOpen((previous) => !previous)}
+              className="flex items-center gap-1 text-[11px] font-semibold uppercase tracking-wide text-slate-300"
+              aria-expanded={isLibraryOpen}
+              aria-controls="template-library-content"
+            >
+              {isLibraryOpen ? 'Hide library' : 'Show library'}
+              <ChevronDownIcon
+                className={`w-4 h-4 text-slate-400 transition-transform ${isLibraryOpen ? 'rotate-180' : ''}`}
+              />
+            </button>
+          </div>
         </div>
         <p className="text-sm text-slate-400">
           Drop in single artifacts to expand a project a la carte. Each blueprint mirrors the categories above but won&apos;t touch dashboards or quests.
@@ -183,26 +198,28 @@ const TemplateGallery: React.FC<TemplateGalleryProps> = ({ categories, projectTe
         </div>
       </header>
 
-      {recommended.length > 0 && (
-        <div className="space-y-4">
-          <div className="text-xs font-semibold text-cyan-300 uppercase tracking-wide">Tailored for {activeProjectTitle}</div>
+      <Zippy isOpen={isLibraryOpen} id="template-library-content" className="space-y-6">
+        {recommended.length > 0 && (
           <div className="space-y-4">
-            {recommended.map((category) => renderCategoryCard(category, true))}
+            <div className="text-xs font-semibold text-cyan-300 uppercase tracking-wide">Tailored for {activeProjectTitle}</div>
+            <div className="space-y-4">
+              {recommended.map((category) => renderCategoryCard(category, true))}
+            </div>
+          </div>
+        )}
+
+        <div className="space-y-4">
+          {recommended.length > 0 && (
+            <div className="text-xs font-semibold text-slate-400 uppercase tracking-wide">More creative kits</div>
+          )}
+          <div className="space-y-4">
+            {others.map((category) => renderCategoryCard(category, false))}
+            {recommended.length === 0 && others.length === 0 && (
+              <p className="text-sm text-slate-500">No templates match that search just yet. Try a different keyword.</p>
+            )}
           </div>
         </div>
-      )}
-
-      <div className="space-y-4">
-        {recommended.length > 0 && (
-          <div className="text-xs font-semibold text-slate-400 uppercase tracking-wide">More creative kits</div>
-        )}
-        <div className="space-y-4">
-          {others.map((category) => renderCategoryCard(category, false))}
-          {recommended.length === 0 && others.length === 0 && (
-            <p className="text-sm text-slate-500">No templates match that search just yet. Try a different keyword.</p>
-          )}
-        </div>
-      </div>
+      </Zippy>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- add a collapsible Zippy wrapper to the Template Library and Project Templates sections with header toggle controls
- wrap the Milestone Tracker cards in a Zippy container so the roadmap can be collapsed without losing context

## Testing
- npm run build
- npm run test:e2e *(fails: Playwright browser binaries are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690284721a288328ab986b1c44d15cc4