### PR TITLE
Fix Playwright smoke test to use guest workspace

### DIFF
--- a/code/e2e/app.spec.ts
+++ b/code/e2e/app.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('Creative Atlas smoke test', () => {
   test('loads the dashboard shell', async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/?guest=1');
     await expect(page.getByRole('heading', { name: 'Creative Atlas' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'New Seed' })).toBeVisible();
     await expect(page.getByText('Daily Quests')).toBeVisible();


### PR DESCRIPTION
## Summary
- update the Playwright smoke test to open the app in guest mode so the dashboard UI is available without authentication

## Testing
- npm run build
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_6902886be1a883289a49f84d23d94dfd