### PR TITLE
Wire up project and artifact deletion

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -647,9 +647,11 @@ export default function App() {
     ensureProjectArtifacts,
     createProject,
     updateProject,
+    deleteProject,
     createArtifact,
     createArtifactsBulk,
     updateArtifact,
+    deleteArtifact,
     mergeArtifacts,
     canLoadMoreProjects,
     loadMoreProjects,
@@ -813,6 +815,18 @@ export default function App() {
     [artifacts, updateArtifact],
   );
 
+  const handleDeleteArtifact = useCallback(
+    async (artifactId: string) => {
+      const success = await deleteArtifact(artifactId);
+      if (!success) {
+        alert('Failed to delete artifact. Please try again later.');
+        return;
+      }
+      setSelectedArtifactId((current) => (current === artifactId ? null : current));
+    },
+    [deleteArtifact],
+  );
+
   const handleSelectProject = (id: string) => {
     setSelectedProjectId(id);
     setSelectedArtifactId(null);
@@ -841,6 +855,28 @@ export default function App() {
       setSelectedArtifactId(null);
     },
     [profile, createProject, addXp],
+  );
+
+  const handleDeleteProject = useCallback(
+    async (projectId: string) => {
+      const projectArtifactIds = artifacts
+        .filter((artifact) => artifact.projectId === projectId)
+        .map((artifact) => artifact.id);
+      const success = await deleteProject(projectId);
+      if (!success) {
+        alert('Failed to delete project. Please try again later.');
+        return;
+      }
+      setProjectActivityLog((prev) => {
+        const { [projectId]: _removed, ...rest } = prev;
+        return rest;
+      });
+      setSelectedProjectId((current) => (current === projectId ? null : current));
+      setSelectedArtifactId((current) =>
+        current && projectArtifactIds.includes(current) ? null : current,
+      );
+    },
+    [artifacts, deleteProject],
   );
 
   const handleCreateArtifact = useCallback(
@@ -1198,6 +1234,7 @@ export default function App() {
               <ProjectOverview
                   project={selectedProject}
                   onUpdateProject={handleUpdateProject}
+                  onDeleteProject={handleDeleteProject}
               />
               <ProjectInsights artifacts={projectArtifacts} />
               <MilestoneTracker items={milestoneProgress} />
@@ -1331,12 +1368,13 @@ export default function App() {
                         </div>
                     )}
                     <ArtifactDetail
-                        artifact={selectedArtifact}
-                        projectArtifacts={projectArtifacts}
-                        onUpdateArtifact={handleUpdateArtifact}
-                        onAddRelation={handleAddRelation}
-                        onRemoveRelation={handleRemoveRelation}
-                        addXp={addXp}
+                      artifact={selectedArtifact}
+                      projectArtifacts={projectArtifacts}
+                      onUpdateArtifact={handleUpdateArtifact}
+                      onAddRelation={handleAddRelation}
+                      onRemoveRelation={handleRemoveRelation}
+                      onDeleteArtifact={handleDeleteArtifact}
+                      addXp={addXp}
                     />
                     {selectedArtifact.type === ArtifactType.Conlang && (
                         <ConlangLexiconEditor

--- a/code/components/ArtifactDetail.tsx
+++ b/code/components/ArtifactDetail.tsx
@@ -11,6 +11,7 @@ interface ArtifactDetailProps {
   onUpdateArtifact: (artifactId: string, updates: Partial<Artifact>) => void;
   onAddRelation: (fromId: string, toId: string, kind: string) => void;
   onRemoveRelation: (fromId: string, relationIndex: number) => void;
+  onDeleteArtifact: (artifactId: string) => Promise<void> | void;
   addXp: (amount: number) => void;
 }
 
@@ -22,6 +23,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
   onUpdateArtifact,
   onAddRelation,
   onRemoveRelation,
+  onDeleteArtifact,
   addXp,
 }) => {
   const [isExpanding, setIsExpanding] = useState(false);
@@ -141,12 +143,29 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
             </div>
             <p className="text-sm text-slate-400 mt-2">Type: <span className="font-semibold text-cyan-400">{artifact.type}</span></p>
           </div>
-          <button
-            onClick={() => exportArtifactToMarkdown(artifact)}
-            className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-md transition-colors"
-          >
-            <ArrowDownTrayIcon className="w-4 h-4" /> Export .md
-          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => exportArtifactToMarkdown(artifact)}
+              className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-md transition-colors"
+            >
+              <ArrowDownTrayIcon className="w-4 h-4" /> Export .md
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                const confirmed = window.confirm(
+                  `Delete artifact "${artifact.title}"? This cannot be undone.`,
+                );
+                if (!confirmed) {
+                  return;
+                }
+                void onDeleteArtifact(artifact.id);
+              }}
+              className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-rose-100 bg-rose-600/20 border border-rose-500/30 rounded-md hover:bg-rose-600/30 transition-colors"
+            >
+              <XMarkIcon className="w-4 h-4" /> Delete
+            </button>
+          </div>
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">

--- a/code/components/ProjectOverview.tsx
+++ b/code/components/ProjectOverview.tsx
@@ -6,6 +6,7 @@ import { TagIcon, XMarkIcon } from './Icons';
 interface ProjectOverviewProps {
   project: Project;
   onUpdateProject: (projectId: string, updates: Partial<Project>) => void;
+  onDeleteProject: (projectId: string) => Promise<void> | void;
 }
 
 const statusOrder: ProjectStatus[] = [
@@ -15,7 +16,7 @@ const statusOrder: ProjectStatus[] = [
   ProjectStatus.Archived,
 ];
 
-const ProjectOverview: React.FC<ProjectOverviewProps> = ({ project, onUpdateProject }) => {
+const ProjectOverview: React.FC<ProjectOverviewProps> = ({ project, onUpdateProject, onDeleteProject }) => {
   const [isEditingSummary, setIsEditingSummary] = useState(false);
   const [summaryDraft, setSummaryDraft] = useState(project.summary);
   const [summaryError, setSummaryError] = useState<string | null>(null);
@@ -110,6 +111,21 @@ const ProjectOverview: React.FC<ProjectOverviewProps> = ({ project, onUpdateProj
               </option>
             ))}
           </select>
+          <button
+            type="button"
+            onClick={() => {
+              const confirmed = window.confirm(
+                `Delete project "${project.title}"? This will also remove its artifacts.`,
+              );
+              if (!confirmed) {
+                return;
+              }
+              void onDeleteProject(project.id);
+            }}
+            className="px-3 py-2 text-xs font-semibold text-rose-100 bg-rose-600/20 border border-rose-500/30 rounded-md hover:bg-rose-600/30 transition-colors"
+          >
+            Delete project
+          </button>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- expose `deleteProject`/`deleteArtifact` in `UserDataContext` and delegate to the data API for persistence
- update the dashboard logic to call the new deletion helpers and keep local selection state in sync
- surface delete controls in the project overview and artifact detail views with confirmation prompts

## Testing
- npm run build
- npm run test:e2e *(fails: Playwright browser binaries are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902883eec0883289ab429c773d1402e