### PR TITLE
Fix lint errors in MilestoneTracker and UserDataContext

### DIFF
--- a/code/components/MilestoneTracker.tsx
+++ b/code/components/MilestoneTracker.tsx
@@ -30,11 +30,11 @@ const StatusIcon: React.FC<{ status: ObjectiveStatus; className?: string }> = ({
 };
 
 const MilestoneTracker: React.FC<MilestoneTrackerProps> = ({ items }) => {
+  const [isTrackerOpen, setIsTrackerOpen] = useState(true);
+
   if (items.length === 0) {
     return null;
   }
-
-  const [isTrackerOpen, setIsTrackerOpen] = useState(true);
 
   return (
     <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">

--- a/code/contexts/UserDataContext.tsx
+++ b/code/contexts/UserDataContext.tsx
@@ -352,7 +352,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         return null;
       }
     },
-    [getIdToken, isDataApiConfigured, isGuestMode, profile],
+    [getIdToken, isGuestMode, profile],
   );
 
   const updateProject = useCallback(
@@ -385,7 +385,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         return null;
       }
     },
-    [getIdToken, isDataApiConfigured, isGuestMode, projects],
+    [getIdToken, isGuestMode, projects],
   );
 
   const createArtifactsBulk = useCallback(
@@ -426,7 +426,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         return [];
       }
     },
-    [getIdToken, isDataApiConfigured, isGuestMode, mergeArtifacts, profile?.uid],
+    [getIdToken, isGuestMode, mergeArtifacts, profile?.uid],
   );
 
   const createArtifact = useCallback(
@@ -487,22 +487,28 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         return null;
       }
     },
-    [artifacts, getIdToken, isDataApiConfigured, isGuestMode],
+    [artifacts, getIdToken, isGuestMode],
   );
 
   const updateProfile = useCallback(
     async (update: ProfileUpdate) => {
+      let shouldPersist = false;
+      let nextAchievements: string[] | undefined;
+      let nextQuestlines: string[] | undefined;
+      let nextSettings: UserSettings | undefined;
+
       setProfile((current) => {
         if (!current) {
           return current;
         }
-        const nextAchievements = update.achievementsUnlocked
+        shouldPersist = true;
+        nextAchievements = update.achievementsUnlocked
           ? Array.from(new Set([...current.achievementsUnlocked, ...update.achievementsUnlocked]))
           : current.achievementsUnlocked;
-        const nextQuestlines = update.questlinesClaimed
+        nextQuestlines = update.questlinesClaimed
           ? Array.from(new Set([...current.questlinesClaimed, ...update.questlinesClaimed]))
           : current.questlinesClaimed;
-        const nextSettings = update.settings
+        nextSettings = update.settings
           ? { ...current.settings, ...update.settings }
           : current.settings;
         return {
@@ -513,6 +519,10 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
           settings: nextSettings,
         };
       });
+
+      if (!shouldPersist) {
+        return;
+      }
 
       if (isGuestMode || !isDataApiConfigured) {
         return;
@@ -535,7 +545,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         console.error('Failed to persist profile update', error);
       }
     },
-    [getIdToken, isDataApiConfigured, isGuestMode],
+    [getIdToken, isGuestMode],
   );
 
   const addXp = useCallback(
@@ -584,7 +594,7 @@ export const UserDataProvider: React.FC<{ children: React.ReactNode }> = ({ chil
         console.error('Failed to persist XP changes', error);
       }
     },
-    [getIdToken, isDataApiConfigured, isGuestMode],
+    [getIdToken, isGuestMode],
   );
 
   const value = useMemo<UserDataContextValue>(


### PR DESCRIPTION
## Summary
- ensure MilestoneTracker initializes hooks before conditional returns to satisfy lint rules
- reuse derived profile updates when persisting changes and drop unnecessary data API dependencies from callbacks

## Testing
- `npm run lint`
- `npm run build`
- `npm run test:e2e` *(fails: missing Playwright browsers in environment)*

------
https://chatgpt.com/codex/tasks/task_e_69028ba7d1f8832892f9dad3a0e7461e