### PR TITLE
Fix profile persistence for achievements and settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A playful, gamified personal knowledge system for organizing web comics, wikis, 
 ### Authentication, Authorization, and Profiles
 - [x] Add sign-up and login flows with token-based authentication for the web client.
 - [x] Associate every project and artifact with an owner and enforce row-level authorization rules.
-- [ ] Persist user-specific settings, XP totals, and achievements so progress follows accounts across devices.
+- [x] Persist user-specific settings, XP totals, and achievements so progress follows accounts across devices.
 
 ### Collaboration & Offline-Resilient UX (do not implement yet)
 - [ ] Decide on collaboration scope (real-time, turn-based, etc.) and add the necessary synchronization layer (websockets, CRDTs) for shared editing.


### PR DESCRIPTION
## Summary
- capture merged achievements, questlines, and settings before invoking the profile update API
- skip API persistence when no authenticated profile is available
- mark the productionization roadmap item for user-specific persistence as complete

## Testing
- npm run build
- npm run test:e2e *(fails: Playwright browsers not installed in CI sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_69028b59f27c8328aa5b30d2b281f3ec