### PR TITLE
Use rotating triangle icon for creator profile zippy

### DIFF
--- a/code/components/Icons.tsx
+++ b/code/components/Icons.tsx
@@ -144,6 +144,12 @@ export const ChevronDownIcon: React.FC<{ className?: string }> = ({ className })
   </svg>
 );
 
+export const TriangleToggleIcon: React.FC<{ className?: string }> = ({ className }) => (
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 12' fill='currentColor' className={className}>
+    <path d='M3 2.5L21 6 3 9.5z' />
+  </svg>
+);
+
 export const CalendarIcon: React.FC<{ className?: string }> = ({ className }) => (
     <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
         <path d='M6 2.75a.75.75 0 00-1.5 0V4H3.5A1.5 1.5 0 002 5.5v11A1.5 1.5 0 003.5 18h13a1.5 1.5 0 001.5-1.5v-11A1.5 1.5 0 0016.5 4H15V2.75a.75.75 0 00-1.5 0V4h-7V2.75z' />

--- a/code/components/UserProfileCard.tsx
+++ b/code/components/UserProfileCard.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { ThemePreference, UserProfile } from '../types';
 import { useAuth } from '../contexts/AuthContext';
+import { TriangleToggleIcon } from './Icons';
 
 interface UserProfileCardProps {
   profile: UserProfile;
@@ -99,12 +100,14 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({ profile, onUpdateProf
             <button
               type="button"
               onClick={() => setIsExpanded((previous) => !previous)}
-              className="flex h-6 w-6 items-center justify-center rounded-full border border-cyan-500/60 bg-slate-800/70 text-sm font-semibold text-cyan-200 transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+              className="flex h-6 w-6 items-center justify-center rounded-full border border-cyan-500/60 bg-slate-800/70 text-cyan-200 transition-transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-cyan-500"
               aria-label={isExpanded ? 'Hide preferences' : 'Show preferences'}
               aria-expanded={isExpanded}
               aria-controls={preferencesPanelId}
             >
-              {isExpanded ? 'v' : '>'}
+              <TriangleToggleIcon
+                className={`h-3.5 w-3.5 transition-transform duration-300 ease-in-out ${isExpanded ? 'rotate-90' : 'rotate-0'}`}
+              />
             </button>
           </div>
           <div>


### PR DESCRIPTION
## Summary
- replace the creator profile zippy text glyph with a reusable SVG triangle toggle icon
- animate the icon rotation when the profile preferences panel expands or collapses

## Testing
- npm run build
- npm run test:e2e *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_69028c8c3c308328971e951c92f5caa3