### PR TITLE
Persist profile preferences and achievements

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A playful, gamified personal knowledge system for organizing web comics, wikis, 
 ### Authentication, Authorization, and Profiles
 - [x] Add sign-up and login flows with token-based authentication for the web client.
 - [x] Associate every project and artifact with an owner and enforce row-level authorization rules.
-- [ ] Persist user-specific settings, XP totals, and achievements so progress follows accounts across devices.
+- [x] Persist user-specific settings, XP totals, and achievements so progress follows accounts across devices.
 
 ### Collaboration & Offline-Resilient UX (do not implement yet)
 - [ ] Decide on collaboration scope (real-time, turn-based, etc.) and add the necessary synchronization layer (websockets, CRDTs) for shared editing.


### PR DESCRIPTION
## Summary
- merge profile updates inside a Firestore transaction so achievements, questlines, and settings are preserved across devices
- mark the productionization roadmap item for persisting user settings, XP, and achievements as complete

## Testing
- npm run build
- npm run test:e2e *(fails: Playwright browsers not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_69028d167ee48328bd5b2897acc84021