### PR TITLE
Fix flexible CORS origin parsing for App Engine

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,10 +3,17 @@ import cors, { type CorsOptions } from 'cors';
 import morgan from 'morgan';
 import workspaceRouter from './routes/workspace.js';
 
-const allowedOrigins = process.env.ALLOWED_ORIGINS?.split(',').map((origin) => origin.trim()).filter(Boolean) ?? [];
+const rawAllowedOrigins = process.env.ALLOWED_ORIGINS ?? '';
+const parsedAllowedOrigins = rawAllowedOrigins
+  .split(/[\s,]+/)
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+const allowAllOrigins = parsedAllowedOrigins.includes('*');
+const allowedOrigins = allowAllOrigins ? [] : parsedAllowedOrigins;
+const originSetting: CorsOptions['origin'] = allowAllOrigins || allowedOrigins.length === 0 ? '*' : allowedOrigins;
 
 const corsOptions: CorsOptions = {
-  origin: allowedOrigins.length > 0 ? allowedOrigins : '*',
+  origin: originSetting,
   methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
 };


### PR DESCRIPTION
## Summary
- normalize ALLOWED_ORIGINS parsing so comma, space, or newline separated entries resolve correctly
- honor a '*' entry as an allow-all override to prevent accidental CORS blocks on App Engine

## Testing
- npm run build (server)
- npm run build (code)
- npm run test:e2e *(fails: Playwright browsers missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_6902a9faf6388328a262631b3fe2a469