### PR TITLE
Fix duplicate CorsOptions import in server entrypoint

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -3,8 +3,6 @@ import cors, { type CorsOptions } from 'cors';
 import morgan from 'morgan';
 import workspaceRouter from './routes/workspace.js';
 
-import { CorsOptions } from 'cors'; // Assuming you have this import
-
 const defaultAllowedOrigins = ['https://creative-atlas.web.app'];
 
 const rawAllowedOrigins = process.env.ALLOWED_ORIGINS ?? '';


### PR DESCRIPTION
## Summary
- remove the redundant `CorsOptions` import from the server entrypoint to resolve the TypeScript duplicate identifier error

## Testing
- npm run build
- npm run test:e2e *(fails: missing Playwright browsers in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_690363b9ebf08328b6d9250f9cd5a004