### PR TITLE
Visualize milestone progress in roadmap insights

### DIFF
--- a/code/components/Roadmap.tsx
+++ b/code/components/Roadmap.tsx
@@ -1,12 +1,18 @@
 import React from 'react';
-import { Milestone } from '../types';
-import { FlagIcon, SparklesIcon } from './Icons';
+import { FlagIcon, SparklesIcon, CheckCircleIcon } from './Icons';
+import { MilestoneProgressOverview, ObjectiveStatus } from '../utils/milestoneProgress';
 
 interface RoadmapProps {
-  milestones: Milestone[];
+  items: MilestoneProgressOverview[];
 }
 
-const Roadmap: React.FC<RoadmapProps> = ({ milestones }) => {
+const statusCopy: Record<ObjectiveStatus, string> = {
+  complete: 'Complete',
+  'in-progress': 'In progress',
+  'not-started': 'Queued',
+};
+
+const Roadmap: React.FC<RoadmapProps> = ({ items }) => {
   return (
     <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
       <header className="flex items-center gap-3">
@@ -20,34 +26,80 @@ const Roadmap: React.FC<RoadmapProps> = ({ milestones }) => {
       </header>
 
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {milestones.map((milestone) => (
-          <article
-            key={milestone.id}
-            className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-4 space-y-3 shadow-lg shadow-slate-950/20"
-          >
-            <div className="flex items-start justify-between gap-2">
-              <div>
-                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{milestone.timeline}</p>
-                <h4 className="text-lg font-semibold text-slate-200">{milestone.title}</h4>
+        {items.map(({ milestone, objectives, completion }) => {
+          const completionPercent = Math.min(100, Math.max(0, Math.round(completion * 100)));
+
+          return (
+            <article
+              key={milestone.id}
+              className="bg-slate-900/70 border border-slate-700/60 rounded-xl p-4 space-y-3 shadow-lg shadow-slate-950/20"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">{milestone.timeline}</p>
+                  <h4 className="text-lg font-semibold text-slate-200">{milestone.title}</h4>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs font-semibold text-slate-400">{completionPercent}%</span>
+                  <SparklesIcon className="w-5 h-5 text-violet-400" />
+                </div>
               </div>
-              <SparklesIcon className="w-5 h-5 text-violet-400" />
-            </div>
-            <p className="text-sm text-slate-400">{milestone.focus}</p>
-            <ul className="space-y-2 text-sm text-slate-300">
-              {milestone.objectives.map((objective) => (
-                <li
-                  key={objective.id}
-                  className="flex items-start gap-2 bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2"
-                >
-                  <span className="mt-0.5 text-cyan-300">•</span>
-                  <span>{objective.description}</span>
-                </li>
-              ))}
-            </ul>
-          </article>
-        ))}
+              <p className="text-sm text-slate-400">{milestone.focus}</p>
+              <div className="h-1.5 rounded-full bg-slate-800/60">
+                <div
+                  className="h-full rounded-full bg-cyan-400/80"
+                  style={{ width: `${completionPercent}%` }}
+                  aria-hidden
+                />
+              </div>
+              <ul className="space-y-2 text-sm text-slate-300">
+                {objectives.map((objective) => (
+                  <li
+                    key={objective.id}
+                    className="flex items-start gap-3 bg-slate-800/60 border border-slate-700/60 rounded-lg px-3 py-2"
+                  >
+                    <StatusBadge status={objective.status} />
+                    <div className="space-y-1">
+                      <p className="font-medium text-slate-100">{objective.description}</p>
+                      {objective.detail && (
+                        <p className="text-xs text-slate-400">{objective.detail}</p>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </article>
+          );
+        })}
       </div>
     </section>
+  );
+};
+
+const StatusBadge: React.FC<{ status: ObjectiveStatus }> = ({ status }) => {
+  if (status === 'complete') {
+    return (
+      <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500/10 text-emerald-300">
+        <CheckCircleIcon className="h-5 w-5" />
+        <span className="sr-only">{statusCopy[status]}</span>
+      </span>
+    );
+  }
+
+  if (status === 'in-progress') {
+    return (
+      <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full border border-amber-400/60 bg-amber-400/10 text-amber-300">
+        <SparklesIcon className="h-4 w-4" />
+        <span className="sr-only">{statusCopy[status]}</span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="mt-0.5 flex h-6 w-6 items-center justify-center rounded-full border border-slate-600 text-slate-400">
+      <span className="text-xs font-semibold uppercase tracking-wide">•</span>
+      <span className="sr-only">{statusCopy[status]}</span>
+    </span>
   );
 };
 

--- a/code/components/SecondaryInsightsPanel.tsx
+++ b/code/components/SecondaryInsightsPanel.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { AIAssistant, Milestone } from '../types';
+import { AIAssistant } from '../types';
+import { MilestoneProgressOverview } from '../utils/milestoneProgress';
 import { SparklesIcon, XMarkIcon } from './Icons';
 import AICopilotPanel from './AICopilotPanel';
 import Roadmap from './Roadmap';
 
 interface SecondaryInsightsPanelProps {
   assistants: AIAssistant[];
-  milestones: Milestone[];
+  milestones: MilestoneProgressOverview[];
   isOpen: boolean;
   onClose: () => void;
 }
@@ -52,7 +53,7 @@ const SecondaryInsightsPanel: React.FC<SecondaryInsightsPanelProps> = ({ assista
 
         <div className="space-y-6 p-6">
           <AICopilotPanel assistants={assistants} />
-          <Roadmap milestones={milestones} />
+          <Roadmap items={milestones} />
         </div>
       </aside>
     </div>


### PR DESCRIPTION
## Summary
- render the milestone roadmap with objective status badges and completion bars
- feed live milestone progress data into the roadmap and secondary insights panel
- surface the next milestone overview card with completion percent in the dashboard

## Testing
- npm run build
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_690377ac4cc08328a03a39c152dad8e2