### PR TITLE
Improve tutorial stepper visuals and navigation

### DIFF
--- a/code/components/Stepper.tsx
+++ b/code/components/Stepper.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import { CheckCircleIcon } from './Icons';
 
 interface StepperProps {
   steps: string[];
@@ -8,15 +9,62 @@ interface StepperProps {
 
 const Stepper: React.FC<StepperProps> = ({ steps, currentStep }) => {
   return (
-    <div className="fixed bottom-0 left-0 w-full bg-slate-900 p-4 border-t border-slate-700 flex justify-around">
-      {steps.map((step, index) => (
-        <div key={index} className={`flex flex-col items-center ${index === currentStep ? 'text-cyan-400' : 'text-slate-500'}`}>
-          <div className={`w-8 h-8 rounded-full flex items-center justify-center font-bold border-2 ${index === currentStep ? 'bg-cyan-400 text-white border-cyan-400' : 'bg-slate-800 border-slate-700'}`}>
-            {index + 1}
-          </div>
-          <div className="mt-2 text-xs text-center">{step}</div>
-        </div>
-      ))}
+    <div className="fixed bottom-0 left-0 w-full border-t border-slate-800/80 bg-slate-950/95 px-4 py-3 backdrop-blur-sm">
+      <nav aria-label="Tutorial progress" className="mx-auto max-w-5xl">
+        <ol className="flex items-center gap-3 text-xs">
+          {steps.map((step, index) => {
+            const isCompleted = index < currentStep;
+            const isActive = index === currentStep;
+            const isLast = index === steps.length - 1;
+
+            return (
+              <li
+                key={step}
+                className={`flex items-center gap-3 ${isLast ? '' : 'flex-1'}`}
+                aria-current={isActive ? 'step' : undefined}
+              >
+                <div className="flex items-center gap-3">
+                  <div
+                    className={[
+                      'flex h-9 w-9 items-center justify-center rounded-full border-2 transition-colors duration-200',
+                      isActive
+                        ? 'border-cyan-400 bg-cyan-500 text-white shadow-lg shadow-cyan-500/30'
+                        : isCompleted
+                          ? 'border-cyan-400/80 bg-cyan-500/20 text-cyan-100'
+                          : 'border-slate-700 bg-slate-900 text-slate-400',
+                    ].join(' ')}
+                  >
+                    {isCompleted ? <CheckCircleIcon className="h-5 w-5" /> : <span className="font-semibold">{index + 1}</span>}
+                  </div>
+                  <span
+                    className={`hidden text-xs font-medium transition-colors duration-200 sm:block ${
+                      isActive
+                        ? 'text-slate-100'
+                        : isCompleted
+                          ? 'text-slate-300'
+                          : 'text-slate-500'
+                    }`}
+                  >
+                    {step}
+                  </span>
+                </div>
+                {!isLast && (
+                  <div
+                    className={`hidden h-0.5 flex-1 rounded-full sm:block ${
+                      isCompleted
+                        ? 'bg-cyan-400/70'
+                        : isActive
+                          ? 'bg-cyan-400/40'
+                          : 'bg-slate-700'
+                    }`}
+                    role="presentation"
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </nav>
     </div>
   );
 };

--- a/code/components/TutorialGuide.tsx
+++ b/code/components/TutorialGuide.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { tutorialSteps } from '../utils/tutorial';
 import TutorialPopover from './TutorialPopover';
-import { TutorialStep } from '../types';
+import Stepper from './Stepper';
 
 const TutorialGuide: React.FC = () => {
   const [currentStep, setCurrentStep] = useState(0);
@@ -40,29 +40,54 @@ const TutorialGuide: React.FC = () => {
   }, [currentStep]);
 
   const handleNextStep = () => {
-    if (currentStep < tutorialSteps.length - 1) {
-      setCurrentStep(currentStep + 1);
-    }
+    setCurrentStep(previous => (previous < tutorialSteps.length - 1 ? previous + 1 : previous));
+  };
+
+  const handlePreviousStep = () => {
+    setCurrentStep(previous => (previous > 0 ? previous - 1 : previous));
   };
 
   const currentTutorialStep = tutorialSteps[currentStep];
-
-  const nextButton = currentTutorialStep.showNextButton ? (
-    <button
-      className="mt-4 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-      onClick={handleNextStep}
-    >
-      Next
-    </button>
-  ) : null;
+  const isLastStep = currentStep === tutorialSteps.length - 1;
+  const canGoBack = currentStep > 0;
 
   return (
-    <TutorialPopover referenceElement={referenceElement} nextButton={nextButton}>
-      <div>
-        <h3 className="text-lg font-bold">{currentTutorialStep.title}</h3>
-        <p className="mt-2">{currentTutorialStep.explanation}</p>
-      </div>
-    </TutorialPopover>
+    <>
+      <Stepper steps={tutorialSteps.map(step => step.title)} currentStep={currentStep} />
+      <TutorialPopover referenceElement={referenceElement}>
+        <div className="space-y-4 text-slate-100">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-50">{currentTutorialStep.title}</h3>
+            <p className="mt-2 text-sm leading-relaxed text-slate-300">{currentTutorialStep.explanation}</p>
+          </div>
+          <div className="flex flex-col gap-3 rounded-lg border border-slate-800 bg-slate-900/60 p-3">
+            <span className="text-xs font-semibold uppercase tracking-wide text-cyan-300">Action</span>
+            <p className="text-sm text-slate-200">{currentTutorialStep.action}</p>
+          </div>
+          {(currentTutorialStep.showNextButton || canGoBack) && (
+            <div className="flex justify-between gap-3 pt-1">
+              <button
+                onClick={handlePreviousStep}
+                className="rounded-md border border-slate-600 bg-slate-800/80 px-4 py-2 text-sm font-medium text-slate-200 transition-colors hover:bg-slate-700 disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={!canGoBack}
+                type="button"
+              >
+                Back
+              </button>
+              {currentTutorialStep.showNextButton && (
+                <button
+                  onClick={handleNextStep}
+                  className="rounded-md bg-cyan-600 px-4 py-2 text-sm font-semibold text-white shadow-md shadow-cyan-600/30 transition-colors hover:bg-cyan-500"
+                  type="button"
+                >
+                  {isLastStep ? 'Finish Tutorial' : 'Mark Step Complete'}
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      </TutorialPopover>
+    </>
   );
 };
 

--- a/code/components/TutorialPopover.tsx
+++ b/code/components/TutorialPopover.tsx
@@ -38,13 +38,13 @@ const TutorialPopover: React.FC<TutorialPopoverProps> = ({ referenceElement, chi
         left: x ?? 0,
         width: 'max-content',
       }}
-      className="bg-white rounded-lg shadow-lg p-4 z-50"
+      className="z-50 rounded-xl border border-slate-800/80 bg-slate-950/95 px-5 py-4 text-slate-100 shadow-2xl shadow-cyan-500/10 backdrop-blur"
     >
       {children}
       {nextButton}
       <div
         ref={arrowRef}
-        className="absolute bg-white w-4 h-4 transform rotate-45"
+        className="absolute h-3 w-3 rotate-45 border border-slate-800/80 bg-slate-950/95"
         style={{
           left: middlewareData.arrow?.x ?? '',
           top: middlewareData.arrow?.y ?? '',


### PR DESCRIPTION
## Summary
- restyle the tutorial stepper with clearer progress states and completed-step indicators
- refresh the tutorial popover with action callouts and complementary dark styling
- add manual navigation controls so users can move backward or finish steps without leaving the overlay

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6905685784208328829d5d99946d3320