### PR TITLE
Expand daily quest rotation with deterministic daily selection

### DIFF
--- a/code/services/dataApi.ts
+++ b/code/services/dataApi.ts
@@ -335,12 +335,12 @@ export const publishToGitHub = async (
   token: string | null,
   repoName: string,
   publishDir: string,
-): Promise<{ message: string, data: any }> => {
+): Promise<{ message: string; data: unknown }> => {
   if (!isDataApiConfigured) {
     throw new Error('Data API is not configured.');
   }
 
-  return sendJson<{ message: string, data: any }>(token, '/api/github/publish', {
+  return sendJson<{ message: string; data: unknown }>(token, '/api/github/publish', {
     method: 'POST',
     body: { repoName, publishDir },
   });


### PR DESCRIPTION
## Summary
- add an expanded daily quest pool and deterministic sampler so players see a new mix every day
- track the current day in app state to refresh the quests when the date rolls over
- tighten the publishToGitHub response typing to avoid implicit any values

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_690570efce68832883a3027faebe325f