### PR TITLE
Fix build failures across frontend and backend

### DIFF
--- a/code/components/Icons.tsx
+++ b/code/components/Icons.tsx
@@ -19,27 +19,37 @@ export const CubeIcon: React.FC<{ className?: string }> = ({ className }) => (
   </svg>
 );
 
-export const GoogleIcon: React.FC<{ className?: string }> = ({ className }) => (
-  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' className={className}>
-    <path d='M23.52 12.2727C23.52 11.4182 23.4418 10.5864 23.2964 9.77734H12V14.4955H18.4582C18.1786 15.9955 17.3373 17.2727 16.0609 18.1273V21.2727H19.8964C22.1973 19.1545 23.52 15.9818 23.52 12.2727Z' fill='#4285F4'/>
-    <path d='M12 24C15.24 24 17.9564 22.9255 19.8964 21.2727L16.0609 18.1273C15.0082 18.8373 13.6345 19.2727 12 19.2727C8.88636 19.2727 6.255 17.1327 5.31682 14.2954H1.34182V17.54C3.27091 21.5182 7.33455 24 12 24Z' fill='#34A853'/>
-    <path d='M5.31682 14.2955C5.08 13.5855 4.94364 12.8255 4.94364 12.0455C4.94364 11.2654 5.08 10.5054 5.30591 9.79543V6.55182H1.34182C0.486364 8.18545 0 10.0582 0 12.0455C0 14.0327 0.486364 15.9054 1.34182 17.5391L5.31682 14.2955Z' fill='#FBBC05'/>
-    <path d='M12 4.72727C13.7955 4.72727 15.375 5.34545 16.6214 6.52727L19.9841 3.16455C17.9455 1.27273 15.24 0 12 0C7.33455 0 3.27091 2.48182 1.34182 6.46091L5.30591 9.79545C6.255 6.95818 8.88636 4.72727 12 4.72727Z' fill='#EA4335'/>
-  </svg>
-);
+  export const GoogleIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' className={className}>
+      <path d='M23.52 12.2727C23.52 11.4182 23.4418 10.5864 23.2964 9.77734H12V14.4955H18.4582C18.1786 15.9955 17.3373 17.2727 16.0609 18.1273V21.2727H19.8964C22.1973 19.1545 23.52 15.9818 23.52 12.2727Z' fill='#4285F4'/>
+      <path d='M12 24C15.24 24 17.9564 22.9255 19.8964 21.2727L16.0609 18.1273C15.0082 18.8373 13.6345 19.2727 12 19.2727C8.88636 19.2727 6.255 17.1327 5.31682 14.2954H1.34182V17.54C3.27091 21.5182 7.33455 24 12 24Z' fill='#34A853'/>
+      <path d='M5.31682 14.2955C5.08 13.5855 4.94364 12.8255 4.94364 12.0455C4.94364 11.2654 5.08 10.5054 5.30591 9.79543V6.55182H1.34182C0.486364 8.18545 0 10.0582 0 12.0455C0 14.0327 0.486364 15.9054 1.34182 17.5391L5.31682 14.2955Z' fill='#FBBC05'/>
+      <path d='M12 4.72727C13.7955 4.72727 15.375 5.34545 16.6214 6.52727L19.9841 3.16455C17.9455 1.27273 15.24 0 12 0C7.33455 0 3.27091 2.48182 1.34182 6.46091L5.30591 9.79545C6.255 6.95818 8.88636 4.72727 12 4.72727Z' fill='#EA4335'/>
+    </svg>
+  );
 
-export const PlusIcon: React.FC<{ className?: string }> = ({ className }) => (
-  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
-    <path d='M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z' />
-  </svg>
-);
+  export const AlertTriangleIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
+      <path
+        fillRule='evenodd'
+        d='M9.401 2.279a1.5 1.5 0 012.598 0l6.328 10.987A1.5 1.5 0 0117.028 16H4.972a1.5 1.5 0 01-1.299-2.734L9.401 2.279zM11 13.5a1 1 0 10-2 0 1 1 0 002 0zm-.75-6.75a.75.75 0 00-1.5 0v3.75a.75.75 0 001.5 0V6.75z'
+        clipRule='evenodd'
+      />
+    </svg>
+  );
 
-export const Spinner: React.FC<{ className?: string }> = ({ className }) => (
-  <svg className={`animate-spin ${className}`} xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
-    <circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4'></circle>
-    <path className='opacity-75' fill='currentColor' d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'></path>
-  </svg>
-);
+  export const PlusIcon: React.FC<{ className?: string }> = ({ className }) => (
+    <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>
+      <path d='M10.75 4.75a.75.75 0 00-1.5 0v4.5h-4.5a.75.75 0 000 1.5h4.5v4.5a.75.75 0 001.5 0v-4.5h4.5a.75.75 0 000-1.5h-4.5v-4.5z' />
+    </svg>
+  );
+
+  export const Spinner: React.FC<{ className?: string }> = ({ className }) => (
+    <svg className={`animate-spin ${className}`} xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 24 24'>
+      <circle className='opacity-25' cx='12' cy='12' r='10' stroke='currentColor' strokeWidth='4'></circle>
+      <path className='opacity-75' fill='currentColor' d='M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z'></path>
+    </svg>
+  );
 
 export const XMarkIcon: React.FC<{ className?: string }> = ({ className }) => (
   <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20' fill='currentColor' className={className}>

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -119,7 +119,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -469,7 +468,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -493,7 +491,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1205,7 +1202,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.4.tgz",
       "integrity": "sha512-pUxEGmR+uu21OG/icAovjlu1fcYJzyVhhT0rsCrn+zi+nHtrS43Bp9KPn9KGa4NMspCUE++nkyiqziuIvJdwzw==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.7.0",
         "@firebase/logger": "0.5.0",
@@ -1272,7 +1268,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.4.tgz",
       "integrity": "sha512-T7ifGmb+awJEcp542Ek4HtNfBxcBrnuk1ggUdqyFEdsXHdq7+wVlhvE6YukTL7NS8hIkEfL7TMAPx/uCNqt30g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app": "0.14.4",
         "@firebase/component": "0.7.0",
@@ -1288,8 +1283,7 @@
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.3.tgz",
       "integrity": "sha512-kRVpIl4vVGJ4baogMDINbyrIOtOxqhkZQg4jTq3l8Lw6WSk0xfpEYzezFu+Kl4ve4fbPl79dvwRtaFqAC/ucCw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth": {
       "version": "1.11.0",
@@ -1740,7 +1734,6 @@
       "integrity": "sha512-0AZUyYUfpMNcztR5l09izHwXkZpghLgCUaAGjtMwXnCg3bj4ml5VgiwqOMOxJ+Nw4qN/zJAaOQBcJ7KGkWStqQ==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       },
@@ -2698,7 +2691,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3033,7 +3027,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3044,7 +3037,6 @@
       "integrity": "sha512-9KQPoO6mZCi7jcIStSnlOWn2nEF3mNmyr3rIAsGnAbQKYbRLyqmeSc39EVgtxXVia+LMT8j3knZLAZAh+xLmrw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3085,7 +3077,6 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -3411,7 +3402,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3885,7 +3875,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -4299,7 +4288,6 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4561,7 +4549,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -4875,7 +4864,6 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6578,7 +6566,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -6609,7 +6596,6 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -6891,6 +6877,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7433,7 +7420,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7538,7 +7524,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -7725,6 +7710,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -7740,6 +7726,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7832,7 +7819,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7842,7 +7828,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -7855,7 +7840,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -9122,7 +9108,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9218,7 +9203,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -10330,7 +10314,6 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,10 @@
 {
-  "name": "creative-atlas",
+  "name": "creative-atlas-monorepo",
   "lockfileVersion": 3,
   "requires": true,
-  "packages": {}
+  "packages": {
+    "": {
+      "name": "creative-atlas-monorepo"
+    }
+  }
 }

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1334,7 +1334,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.24.tgz",
       "integrity": "sha512-FE5u0ezmi6y9OZEzlJfg37mqqf6ZDSF2V/NLjUyGrR9uTZ7Sb9F7bLNZ03S4XVUNRWGA7Ck4c1kK+YnuWjl+DA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3348,7 +3347,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -4079,7 +4077,6 @@
       "integrity": "sha512-ytQKuwgmrrkDTFP4LjR0ToE2nqgy886GpvRSpU0JAnrdBYppuY5rLkRUYPU1yCryb24SsKBTL/hlDQAEFVwtZg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.25.0",
         "get-tsconfig": "^4.7.5"
@@ -4113,7 +4110,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -4200,7 +4196,6 @@
       "integrity": "sha512-ZWyE8YXEXqJrrSLvYgrRP7p62OziLW7xI5HYGWFzOvupfAlrLvURSzv/FyGyy0eidogEM3ujU+kUG1zuHgb6Ug==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",

--- a/server/src/types/session.ts
+++ b/server/src/types/session.ts
@@ -1,0 +1,10 @@
+import 'express-session';
+
+declare module 'express-session' {
+  interface SessionData {
+    github_oauth_state?: string;
+    github_access_token?: string;
+  }
+}
+
+export {};

--- a/server/src/validation/schemas.ts
+++ b/server/src/validation/schemas.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 const relationsSchema = z
   .string()
+  .default('')
   .transform((val, ctx) => {
     if (!val) return [];
     const relations = val
@@ -21,12 +22,11 @@ const relationsSchema = z
       result.push({ kind: kind.trim(), toId: toId.trim() });
     }
     return result;
-  })
-  .optional()
-  .default([]);
+  });
 
 const jsonSchema = z
   .string()
+  .default('{}')
   .transform((val, ctx) => {
     if (!val) return {};
     try {
@@ -38,21 +38,18 @@ const jsonSchema = z
       });
       return z.NEVER;
     }
-  })
-  .optional()
-  .default({});
+  });
 
 const tagsSchema = z
   .string()
+  .default('')
   .transform((val) => {
     if (!val) return [];
     return val
       .split(';')
       .map((s) => s.trim())
       .filter(Boolean);
-  })
-  .optional()
-  .default([]);
+  });
 
 export const CsvRowSchema = z.object({
   id: z.string().trim().min(1, 'ID is required and cannot be empty.'),


### PR DESCRIPTION
## Summary
- export the AlertTriangleIcon used by the confirmation modal to restore the Vite build
- normalize CSV parsing defaults with Zod and extend the Express session typing so the server compiles
- refresh lockfiles after installing frontend and backend dependencies

## Testing
- npm run build --prefix code
- npm run lint --prefix code
- npm run test --prefix code
- npm run build --prefix server
- npm test --prefix server

------
https://chatgpt.com/codex/tasks/task_e_690575812ca08328a96636b5a4b3c3c9