### PR TITLE
Fix tutorial progression for form submissions

### DIFF
--- a/code/components/CreateArtifactForm.tsx
+++ b/code/components/CreateArtifactForm.tsx
@@ -29,7 +29,7 @@ const CreateArtifactForm: React.FC<CreateArtifactFormProps> = ({ onCreate, onClo
   };
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-6">
+    <form id="create-artifact-form" onSubmit={handleSubmit} className="space-y-6">
       <div>
         <label htmlFor="artifact-title" className="block text-sm font-medium text-slate-300 mb-1">
           Title

--- a/code/components/TutorialGuide.tsx
+++ b/code/components/TutorialGuide.tsx
@@ -22,8 +22,9 @@ const TutorialGuide: React.FC = () => {
   useEffect(() => {
     const step = tutorialSteps[currentStep];
     if (step.target) {
-      const element = document.querySelector(step.target) as HTMLElement;
-      setReferenceElement(element);
+      const element = document.querySelector(step.target);
+      setReferenceElement(element instanceof HTMLElement ? element : null);
+      const eventType = step.advanceEvent ?? 'click';
 
       if (step.prefill) {
         Object.entries(step.prefill).forEach(([selector, value]) => {
@@ -35,16 +36,17 @@ const TutorialGuide: React.FC = () => {
       }
 
       if (element) {
-        element.addEventListener('click', handleNextStep);
+        element.addEventListener(eventType, handleNextStep);
       }
     }
 
     return () => {
       const step = tutorialSteps[currentStep];
       if (step.target) {
-        const element = document.querySelector(step.target) as HTMLElement;
+        const element = document.querySelector(step.target);
         if (element) {
-          element.removeEventListener('click', handleNextStep);
+          const eventType = step.advanceEvent ?? 'click';
+          element.removeEventListener(eventType, handleNextStep);
         }
       }
     };

--- a/code/types.ts
+++ b/code/types.ts
@@ -304,4 +304,5 @@ export interface TutorialStep {
   target: string;
   prefill?: { [key: string]: string };
   showNextButton?: boolean;
+  advanceEvent?: 'click' | 'submit';
 }

--- a/code/utils/tutorial.ts
+++ b/code/utils/tutorial.ts
@@ -15,6 +15,7 @@ export const tutorialSteps: TutorialStep[] = [
       "Every great story starts with a project. Give your project a name and a brief description. For our tutorial, we'll use the world of Aethelgard.",
     action: 'Fill in project details',
     target: '#create-project-form',
+    advanceEvent: 'submit',
     prefill: {
       '#project-title': 'Aethelgard',
       '#project-summary': 'A world of magic and adventure.',
@@ -33,6 +34,7 @@ export const tutorialSteps: TutorialStep[] = [
       "A wiki is a great way to organize your world's lore. Give your wiki a title and a short description.",
     action: 'Fill in wiki details',
     target: '#create-artifact-form',
+    advanceEvent: 'submit',
     prefill: {
       '#artifact-title': 'Aethelgard Wiki',
       '#artifact-summary': 'The official wiki for the world of Aethelgard.',


### PR DESCRIPTION
## Summary
- allow tutorial steps to specify the DOM event that advances the tutorial
- advance project and artifact creation steps on form submission and tag the artifact form with the expected id

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_69058587a0988328b71d51cf9fc48ba4