### PR TITLE
Add fact prompts, character depth toggle, and inspiration deck

### DIFF
--- a/code/components/CharacterEditor.tsx
+++ b/code/components/CharacterEditor.tsx
@@ -1,7 +1,6 @@
-
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { Artifact, ArtifactType, CharacterData, CharacterTrait, NARRATIVE_ARTIFACT_TYPES } from '../types';
-import { PlusIcon, XMarkIcon, UserCircleIcon } from './Icons';
+import { PlusIcon, SparklesIcon, UserCircleIcon, XMarkIcon } from './Icons';
 import EditorRelationSidebar from './EditorRelationSidebar';
 
 const CHARACTER_APPEARS_IN_TYPES: ArtifactType[] = [
@@ -14,6 +13,39 @@ const CHARACTER_GEAR_TYPES: ArtifactType[] = [
   ArtifactType.MagicSystem,
   ArtifactType.Conlang,
   ArtifactType.Wiki,
+];
+
+const DEFAULT_CHARACTER_DATA: CharacterData = {
+  bio: '',
+  traits: [],
+  motivation: '',
+  conflict: '',
+  secret: '',
+  narrativeRole: '',
+  arcStage: '',
+  voiceNotes: '',
+  relationships: '',
+};
+
+const NARRATIVE_ROLE_OPTIONS = [
+  'Protagonist',
+  'Deuteragonist',
+  'Antagonist',
+  'Mentor',
+  'Foil',
+  'Wildcard',
+  'Narrator',
+  'Supporting Cast',
+];
+
+const ARC_STAGE_OPTIONS = [
+  'Set-Up',
+  'Inciting Incident',
+  'Rising Complication',
+  'Midpoint Reckoning',
+  'Climax',
+  'Resolution',
+  'Epilogue',
 ];
 
 interface CharacterEditorProps {
@@ -31,23 +63,62 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({
   onAddRelation,
   onRemoveRelation,
 }) => {
-  const data = (artifact.data as CharacterData) || { bio: '', traits: [] };
+  const data: CharacterData = useMemo(
+    () => ({
+      ...DEFAULT_CHARACTER_DATA,
+      ...(artifact.data as CharacterData | undefined),
+    }),
+    [artifact.data],
+  );
+
   const [bio, setBio] = useState(data.bio);
   const [traits, setTraits] = useState<CharacterTrait[]>(data.traits);
   const [newTraitKey, setNewTraitKey] = useState('');
   const [newTraitValue, setNewTraitValue] = useState('');
+  const [motivation, setMotivation] = useState(data.motivation ?? '');
+  const [conflict, setConflict] = useState(data.conflict ?? '');
+  const [secret, setSecret] = useState(data.secret ?? '');
+  const [narrativeRole, setNarrativeRole] = useState(data.narrativeRole ?? '');
+  const [arcStage, setArcStage] = useState(data.arcStage ?? '');
+  const [voiceNotes, setVoiceNotes] = useState(data.voiceNotes ?? '');
+  const [relationships, setRelationships] = useState(data.relationships ?? '');
+  const [showAdvanced, setShowAdvanced] = useState(() => {
+    return Boolean(
+      (data.motivation && data.motivation.trim()) ||
+        (data.conflict && data.conflict.trim()) ||
+        (data.secret && data.secret.trim()) ||
+        (data.narrativeRole && data.narrativeRole.trim()) ||
+        (data.arcStage && data.arcStage.trim()) ||
+        (data.voiceNotes && data.voiceNotes.trim()) ||
+        (data.relationships && data.relationships.trim()),
+    );
+  });
+
+  useEffect(() => {
+    setBio(data.bio ?? '');
+    setTraits(Array.isArray(data.traits) ? data.traits : []);
+    setMotivation(data.motivation ?? '');
+    setConflict(data.conflict ?? '');
+    setSecret(data.secret ?? '');
+    setNarrativeRole(data.narrativeRole ?? '');
+    setArcStage(data.arcStage ?? '');
+    setVoiceNotes(data.voiceNotes ?? '');
+    setRelationships(data.relationships ?? '');
+  }, [artifact.id, data]);
 
   const handleUpdate = (updatedData: Partial<CharacterData>) => {
     onUpdateArtifactData(artifact.id, { ...data, ...updatedData });
   };
 
-  const handleBioChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setBio(e.target.value);
-    handleUpdate({ bio: e.target.value });
+  const handleBioChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setBio(event.target.value);
+    handleUpdate({ bio: event.target.value });
   };
 
   const handleAddTrait = () => {
-    if (!newTraitKey.trim() || !newTraitValue.trim()) return;
+    if (!newTraitKey.trim() || !newTraitValue.trim()) {
+      return;
+    }
     const newTrait: CharacterTrait = {
       id: `trait-${Date.now()}`,
       key: newTraitKey,
@@ -61,71 +132,258 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({
   };
 
   const handleDeleteTrait = (traitId: string) => {
-    const updatedTraits = traits.filter(t => t.id !== traitId);
+    const updatedTraits = traits.filter((trait) => trait.id !== traitId);
     setTraits(updatedTraits);
     handleUpdate({ traits: updatedTraits });
   };
 
-  return (
-    <div className="bg-slate-800/50 rounded-lg p-6 border border-slate-700/50">
-      <h3 className="text-xl font-bold text-blue-400 mb-6 flex items-center gap-2">
-        <UserCircleIcon className="w-6 h-6" />
-        Character Sheet: {artifact.title}
-      </h3>
+  const advancedFieldsActive = useMemo(
+    () =>
+      Boolean(
+        motivation.trim() ||
+          conflict.trim() ||
+          secret.trim() ||
+          narrativeRole.trim() ||
+          arcStage.trim() ||
+          voiceNotes.trim() ||
+          relationships.trim(),
+      ),
+    [motivation, conflict, secret, narrativeRole, arcStage, voiceNotes, relationships],
+  );
 
-      <div className="flex flex-col lg:flex-row gap-6">
-        <div className="flex-1 grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <div className="lg:col-span-2">
-            <label htmlFor="character-bio" className="block text-sm font-medium text-slate-300 mb-1">
-              Biography
-            </label>
-            <textarea
-              id="character-bio"
-              value={bio}
-              onChange={handleBioChange}
-              rows={10}
-              className="w-full bg-slate-700/50 border border-slate-600 rounded-md px-3 py-2 text-slate-200 focus:ring-2 focus:ring-blue-500 focus:border-blue-500 transition"
-              placeholder="Describe the character's history, personality, and appearance..."
-            />
+  const toggleAdvanced = () => {
+    setShowAdvanced((previous) => !previous);
+  };
+
+  return (
+    <div className="rounded-lg border border-slate-700/50 bg-slate-800/50 p-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <h3 className="flex items-center gap-2 text-xl font-bold text-blue-400">
+          <UserCircleIcon className="h-6 w-6" />
+          Character Sheet: {artifact.title}
+        </h3>
+        <div className="flex items-center gap-3">
+          {!showAdvanced && advancedFieldsActive && (
+            <span className="rounded-full border border-cyan-500/40 bg-cyan-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-cyan-200">
+              Depth notes hidden
+            </span>
+          )}
+          <button
+            type="button"
+            onClick={toggleAdvanced}
+            className="inline-flex items-center gap-2 rounded-md border border-cyan-500/40 bg-cyan-500/10 px-3 py-1.5 text-xs font-semibold text-cyan-200 transition-colors hover:bg-cyan-500/20"
+          >
+            <SparklesIcon className="h-4 w-4" />
+            {showAdvanced ? 'Hide depth' : 'Reveal depth'}
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-6 lg:flex-row">
+        <div className="flex-1 space-y-6">
+          <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+            <div className="lg:col-span-2">
+              <label htmlFor="character-bio" className="mb-1 block text-sm font-medium text-slate-300">
+                Biography
+              </label>
+              <textarea
+                id="character-bio"
+                value={bio}
+                onChange={handleBioChange}
+                rows={10}
+                className="w-full rounded-md border border-slate-600 bg-slate-700/50 px-3 py-2 text-slate-200 transition focus:border-blue-500 focus:ring-2 focus:ring-blue-500"
+                placeholder="Describe the character's history, personality, and appearance..."
+              />
+            </div>
+            <div>
+              <h4 className="mb-2 text-sm font-medium text-slate-300">Traits</h4>
+              <div className="mb-4 space-y-2">
+                {traits.map((trait) => (
+                  <div key={trait.id} className="flex items-center gap-2 rounded-md bg-slate-700/50 p-2">
+                    <strong className="text-sm text-slate-300">{trait.key}:</strong>
+                    <span className="flex-grow text-sm text-slate-400">{trait.value}</span>
+                    <button
+                      onClick={() => handleDeleteTrait(trait.id)}
+                      className="p-1 text-slate-500 transition hover:text-rose-400"
+                      type="button"
+                    >
+                      <XMarkIcon className="h-4 w-4" />
+                    </button>
+                  </div>
+                ))}
+                {traits.length === 0 && (
+                  <p className="rounded-md border border-dashed border-slate-700/60 bg-slate-900/50 px-3 py-2 text-xs text-slate-500">
+                    No signature traits yet. Capture quirks, bonds, or stats to bring them to life.
+                  </p>
+                )}
+              </div>
+              <div className="space-y-2 rounded-md border border-slate-700 bg-slate-900/50 p-3">
+                <input
+                  type="text"
+                  value={newTraitKey}
+                  onChange={(event) => setNewTraitKey(event.target.value)}
+                  placeholder="Trait (e.g., Age)"
+                  className="w-full rounded-md border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
+                />
+                <input
+                  type="text"
+                  value={newTraitValue}
+                  onChange={(event) => setNewTraitValue(event.target.value)}
+                  placeholder="Value (e.g., 27)"
+                  className="w-full rounded-md border border-slate-600 bg-slate-800 px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
+                />
+                <button
+                  onClick={handleAddTrait}
+                  className="flex w-full items-center justify-center gap-1 rounded-md bg-blue-600 px-3 py-1 text-sm font-semibold text-white transition-colors hover:bg-blue-500"
+                  type="button"
+                >
+                  <PlusIcon className="h-4 w-4" /> Add Trait
+                </button>
+              </div>
+            </div>
           </div>
-          <div>
-            <h4 className="text-sm font-medium text-slate-300 mb-2">Traits</h4>
-            <div className="space-y-2 mb-4">
-              {traits.map(trait => (
-                <div key={trait.id} className="flex items-center gap-2 bg-slate-700/50 p-2 rounded-md">
-                  <strong className="text-slate-300 text-sm">{trait.key}:</strong>
-                  <span className="text-slate-400 text-sm flex-grow">{trait.value}</span>
-                  <button onClick={() => handleDeleteTrait(trait.id)} className="p-1 text-slate-500 hover:text-red-400">
-                    <XMarkIcon className="w-4 h-4" />
-                  </button>
-                </div>
-              ))}
-              {traits.length === 0 && (
-                <p className="text-xs text-slate-500 bg-slate-900/50 border border-dashed border-slate-700/60 rounded-md px-3 py-2">
-                  No signature traits yet. Capture quirks, bonds, or stats to bring them to life.
+
+          {!showAdvanced && advancedFieldsActive && (
+            <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 px-4 py-3 text-sm text-cyan-100">
+              Detailed notes are saved for this character. Reveal depth to review or edit them.
+            </div>
+          )}
+
+          {showAdvanced && (
+            <section className="space-y-4 rounded-lg border border-cyan-500/30 bg-slate-900/50 p-5">
+              <header className="space-y-1">
+                <p className="text-xs font-semibold uppercase tracking-wide text-cyan-300">Deep Cut Layers</p>
+                <h4 className="text-lg font-semibold text-slate-100">Narrative depth &amp; canon anchors</h4>
+                <p className="text-sm text-slate-400">
+                  Capture motivations, secrets, and arc signals to keep this character consistent across stories.
                 </p>
-              )}
-            </div>
-            <div className="space-y-2 p-3 bg-slate-900/50 rounded-md border border-slate-700">
-              <input
-                type="text"
-                value={newTraitKey}
-                onChange={e => setNewTraitKey(e.target.value)}
-                placeholder="Trait (e.g., Age)"
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
-              />
-              <input
-                type="text"
-                value={newTraitValue}
-                onChange={e => setNewTraitValue(e.target.value)}
-                placeholder="Value (e.g., 27)"
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
-              />
-              <button onClick={handleAddTrait} className="w-full flex items-center justify-center gap-1 px-3 py-1 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-500 rounded-md transition-colors">
-                <PlusIcon className="w-4 h-4" /> Add Trait
-              </button>
-            </div>
-          </div>
+              </header>
+              <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+                <div className="md:col-span-2">
+                  <label htmlFor="character-motivation" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Motivation &amp; desire
+                  </label>
+                  <textarea
+                    id="character-motivation"
+                    value={motivation}
+                    onChange={(event) => {
+                      setMotivation(event.target.value);
+                      handleUpdate({ motivation: event.target.value });
+                    }}
+                    rows={3}
+                    className="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-200 focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/60"
+                    placeholder="What future are they chasing? Who are they trying to protect or defy?"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="character-conflict" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Core conflict
+                  </label>
+                  <textarea
+                    id="character-conflict"
+                    value={conflict}
+                    onChange={(event) => {
+                      setConflict(event.target.value);
+                      handleUpdate({ conflict: event.target.value });
+                    }}
+                    rows={3}
+                    className="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-200 focus:border-amber-500 focus:outline-none focus:ring-2 focus:ring-amber-500/40"
+                    placeholder="What stands in their way? Name the internal or external friction."
+                  />
+                </div>
+                <div>
+                  <label htmlFor="character-secret" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Secrets &amp; twists
+                  </label>
+                  <textarea
+                    id="character-secret"
+                    value={secret}
+                    onChange={(event) => {
+                      setSecret(event.target.value);
+                      handleUpdate({ secret: event.target.value });
+                    }}
+                    rows={3}
+                    className="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-200 focus:border-pink-500 focus:outline-none focus:ring-2 focus:ring-pink-500/40"
+                    placeholder="Hidden loyalties, ticking bombs, or revelations waiting to surface."
+                  />
+                </div>
+                <div>
+                  <label htmlFor="character-role" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Narrative role
+                  </label>
+                  <select
+                    id="character-role"
+                    value={narrativeRole}
+                    onChange={(event) => {
+                      setNarrativeRole(event.target.value);
+                      handleUpdate({ narrativeRole: event.target.value });
+                    }}
+                    className="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-200 focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+                  >
+                    <option value="">Choose a role...</option>
+                    {NARRATIVE_ROLE_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="character-arc-stage" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Arc stage
+                  </label>
+                  <select
+                    id="character-arc-stage"
+                    value={arcStage}
+                    onChange={(event) => {
+                      setArcStage(event.target.value);
+                      handleUpdate({ arcStage: event.target.value });
+                    }}
+                    className="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-200 focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500/40"
+                  >
+                    <option value="">Select a beat...</option>
+                    {ARC_STAGE_OPTIONS.map((option) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div>
+                  <label htmlFor="character-relationships" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Relationships &amp; anchors
+                  </label>
+                  <textarea
+                    id="character-relationships"
+                    value={relationships}
+                    onChange={(event) => {
+                      setRelationships(event.target.value);
+                      handleUpdate({ relationships: event.target.value });
+                    }}
+                    rows={3}
+                    className="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-200 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+                    placeholder="Allies, rivals, patrons, or debts that define their orbit."
+                  />
+                </div>
+                <div className="md:col-span-2">
+                  <label htmlFor="character-voice" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-slate-400">
+                    Voice &amp; cadence
+                  </label>
+                  <textarea
+                    id="character-voice"
+                    value={voiceNotes}
+                    onChange={(event) => {
+                      setVoiceNotes(event.target.value);
+                      handleUpdate({ voiceNotes: event.target.value });
+                    }}
+                    rows={2}
+                    className="w-full rounded-md border border-slate-700 bg-slate-900/80 px-3 py-2 text-sm text-slate-200 focus:border-indigo-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    placeholder="Speech quirks, diction notes, or tonal references."
+                  />
+                </div>
+              </div>
+            </section>
+          )}
         </div>
 
         <div className="lg:w-80 xl:w-96">

--- a/code/components/InspirationDeck.tsx
+++ b/code/components/InspirationDeck.tsx
@@ -1,0 +1,239 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { SparklesIcon } from './Icons';
+
+interface InspirationCard {
+  id: string;
+  title: string;
+  archetype: string;
+  vibe: string;
+  prompt: string;
+  tags: string[];
+  booster: string;
+}
+
+const INSPIRATION_CARDS: InspirationCard[] = [
+  {
+    id: 'ember-mentor',
+    title: "Ember Mentor",
+    archetype: 'Character Catalyst',
+    vibe: 'Warm Resolve',
+    prompt: 'A veteran mage whose magic now manifests as clockwork sparks agrees to teach only if the apprentice unearths a forgotten failure.',
+    tags: ['character', 'mentor', 'clockwork'],
+    booster: 'Pair with a Task artifact to draft the apprentice’s proving ritual.',
+  },
+  {
+    id: 'fracture-vault',
+    title: 'Fracture Vault',
+    archetype: 'Location Anchor',
+    vibe: 'Tense Stillness',
+    prompt: 'Beneath the Whisperwood sits a vault that only opens when three rival factions speak in unison.',
+    tags: ['location', 'faction', 'puzzle'],
+    booster: 'Link to your faction board and outline the negotiation scene.',
+  },
+  {
+    id: 'loreline',
+    title: 'Loreline Glitch',
+    archetype: 'Continuity Spark',
+    vibe: 'Electric Mystery',
+    prompt: 'The timeline UI now shows a ghost entry—an event that never happened but feels inevitable.',
+    tags: ['timeline', 'mystery'],
+    booster: 'Create a quest to decide whether to embrace or erase the phantom event.',
+  },
+  {
+    id: 'conlang-chime',
+    title: 'Chime Lexeme',
+    archetype: 'Language Flavor',
+    vibe: 'Playful Insight',
+    prompt: 'A new conlang word evokes both thunder and laughter, inspiring a festival tradition that only appears every ten years.',
+    tags: ['conlang', 'culture', 'festival'],
+    booster: 'Draft a wiki entry or card describing the festival’s games.',
+  },
+  {
+    id: 'xp-harvest',
+    title: 'XP Harvest',
+    archetype: 'Gameplay Boost',
+    vibe: 'High Energy',
+    prompt: 'Completing a trio of micro-quests tonight grants a temporary XP multiplier for collaborative drafts.',
+    tags: ['quest', 'xp', 'loop'],
+    booster: 'Add three bite-sized quests to tonight’s board.',
+  },
+  {
+    id: 'ally-mask',
+    title: 'Ally Behind the Mask',
+    archetype: 'Twist Hook',
+    vibe: 'Suspenseful Pulse',
+    prompt: 'A masked informant slips a relic onto the table—engraved with the protagonist’s childhood nickname.',
+    tags: ['twist', 'relic', 'relationship'],
+    booster: 'Log a character trait or scene card revealing why they left.',
+  },
+  {
+    id: 'map-fissure',
+    title: 'Fissure Atlas',
+    archetype: 'Visual Prompt',
+    vibe: 'Crumbling Awe',
+    prompt: 'Your project map develops a spreading fissure overlay that traces where reality is thinnest.',
+    tags: ['map', 'visual', 'threat'],
+    booster: 'Sketch the three locations most at risk and link them together.',
+  },
+  {
+    id: 'memory-orb',
+    title: 'Memory Orb',
+    archetype: 'Relic Memory',
+    vibe: 'Melancholic Wonder',
+    prompt: 'A crystalline orb replays one pivotal choice differently every time someone touches it.',
+    tags: ['relic', 'memory', 'what-if'],
+    booster: 'Write alternative beats for a key scene using the orb as catalyst.',
+  },
+];
+
+const drawRandomCard = (excludeId?: string): InspirationCard => {
+  const pool = excludeId ? INSPIRATION_CARDS.filter((card) => card.id !== excludeId) : INSPIRATION_CARDS;
+  if (pool.length === 0) {
+    throw new Error('Inspiration deck is empty.');
+  }
+  return pool[Math.floor(Math.random() * pool.length)];
+};
+
+const InspirationDeck: React.FC = () => {
+  const [currentCard, setCurrentCard] = useState<InspirationCard | null>(null);
+  const [history, setHistory] = useState<InspirationCard[]>([]);
+  const [copyState, setCopyState] = useState<'idle' | 'copied' | 'error'>('idle');
+  const [isLocked, setIsLocked] = useState(false);
+
+  const canDraw = useMemo(() => INSPIRATION_CARDS.length > 0, []);
+
+  useEffect(() => {
+    if (copyState === 'idle') {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      setCopyState('idle');
+    }, 2200);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [copyState]);
+
+  const handleDrawCard = () => {
+    if (!canDraw || isLocked) {
+      return;
+    }
+    setHistory((previous) => (currentCard ? [currentCard, ...previous].slice(0, 4) : previous));
+    const nextCard = drawRandomCard(currentCard?.id);
+    setCurrentCard(nextCard);
+    setCopyState('idle');
+  };
+
+  const handleToggleLock = () => {
+    if (!currentCard) {
+      return;
+    }
+    setIsLocked((locked) => !locked);
+  };
+
+  const handleCopyPrompt = async () => {
+    if (!currentCard) {
+      return;
+    }
+    try {
+      await navigator.clipboard.writeText(currentCard.prompt);
+      setCopyState('copied');
+    } catch (error) {
+      console.warn('Failed to copy inspiration prompt', error);
+      setCopyState('error');
+    }
+  };
+
+  return (
+    <section className="space-y-5 rounded-2xl border border-violet-500/30 bg-slate-900/60 p-6">
+      <header className="space-y-2">
+        <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-violet-300">
+          <SparklesIcon className="h-4 w-4" /> Inspiration Deck
+        </div>
+        <h3 className="text-xl font-semibold text-slate-100">Draw a fresh creative boost</h3>
+        <p className="text-sm text-slate-400">
+          Each card blends archetypes, vibes, and boosters sourced from the Aethelgard design kit. Draw one when a scene stalls or when you need a quest hook fast.
+        </p>
+      </header>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleDrawCard}
+          disabled={!canDraw || isLocked}
+          className="inline-flex items-center gap-2 rounded-md bg-violet-600 px-4 py-2 text-sm font-semibold text-white transition-colors disabled:cursor-not-allowed disabled:opacity-50 hover:bg-violet-500"
+        >
+          Shuffle &amp; Draw
+        </button>
+        <button
+          type="button"
+          onClick={handleToggleLock}
+          disabled={!currentCard}
+          className="rounded-md border border-slate-600 px-3 py-2 text-xs font-semibold text-slate-200 transition-colors disabled:cursor-not-allowed disabled:opacity-40 hover:border-slate-400 hover:text-white"
+        >
+          {isLocked ? 'Unlock card' : 'Lock card'}
+        </button>
+        {currentCard && (
+          <span className={`text-xs font-semibold uppercase tracking-wide ${isLocked ? 'text-emerald-300' : 'text-slate-500'}`}>
+            {isLocked ? 'Card locked in place' : 'Card free to draw'}
+          </span>
+        )}
+      </div>
+
+      {currentCard ? (
+        <article className="space-y-4 rounded-xl border border-violet-500/40 bg-slate-950/60 p-5 shadow-lg shadow-violet-900/30">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-violet-300">{currentCard.archetype}</p>
+              <h4 className="text-lg font-semibold text-slate-100">{currentCard.title}</h4>
+            </div>
+            <span className="rounded-full border border-violet-500/40 bg-violet-500/10 px-3 py-1 text-xs font-semibold text-violet-200">
+              {currentCard.vibe}
+            </span>
+          </div>
+          <p className="text-sm leading-relaxed text-slate-200">{currentCard.prompt}</p>
+          <div className="flex flex-wrap gap-2">
+            {currentCard.tags.map((tag) => (
+              <span key={tag} className="rounded-full border border-slate-700 bg-slate-900/70 px-3 py-1 text-xs font-medium text-slate-300">
+                #{tag}
+              </span>
+            ))}
+          </div>
+          <div className="rounded-lg border border-slate-700/70 bg-slate-900/70 p-3 text-xs text-slate-300">
+            Booster: {currentCard.booster}
+          </div>
+          <div className="flex flex-wrap items-center gap-2">
+            <button
+              type="button"
+              onClick={handleCopyPrompt}
+              className="rounded-md border border-slate-600 px-3 py-1.5 text-xs font-semibold text-slate-200 transition-colors hover:border-slate-400 hover:text-white"
+            >
+              Copy prompt
+            </button>
+            {copyState === 'copied' && <span className="text-xs font-semibold text-emerald-300">Copied!</span>}
+            {copyState === 'error' && <span className="text-xs font-semibold text-rose-300">Copy failed—use Ctrl/Cmd + C</span>}
+          </div>
+        </article>
+      ) : (
+        <p className="rounded-lg border border-dashed border-violet-500/30 bg-slate-950/40 px-4 py-6 text-sm text-slate-400">
+          Shuffle the deck to reveal a card. Each draw delivers a ready-to-use beat that you can slot into a wiki entry, quest, or scene card.
+        </p>
+      )}
+
+      {history.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Recent draws</p>
+          <div className="flex flex-wrap gap-2">
+            {history.map((card) => (
+              <span key={card.id} className="rounded-md border border-slate-700 bg-slate-900/60 px-3 py-1 text-xs text-slate-300">
+                {card.title}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+};
+
+export default InspirationDeck;

--- a/code/components/SecondaryInsightsPanel.tsx
+++ b/code/components/SecondaryInsightsPanel.tsx
@@ -3,6 +3,7 @@ import { AIAssistant } from '../types';
 import { MilestoneProgressOverview } from '../utils/milestoneProgress';
 import { SparklesIcon, XMarkIcon } from './Icons';
 import AICopilotPanel from './AICopilotPanel';
+import InspirationDeck from './InspirationDeck';
 import Roadmap from './Roadmap';
 
 interface SecondaryInsightsPanelProps {
@@ -54,6 +55,7 @@ const SecondaryInsightsPanel: React.FC<SecondaryInsightsPanelProps> = ({ assista
         <div className="space-y-6 p-6">
           <AICopilotPanel assistants={assistants} />
           <Roadmap items={milestones} />
+          <InspirationDeck />
         </div>
       </aside>
     </div>

--- a/code/types.ts
+++ b/code/types.ts
@@ -82,6 +82,13 @@ export interface CharacterTrait {
 export interface CharacterData {
     bio: string;
     traits: CharacterTrait[];
+    motivation?: string;
+    conflict?: string;
+    secret?: string;
+    narrativeRole?: string;
+    arcStage?: string;
+    voiceNotes?: string;
+    relationships?: string;
 }
 
 export interface WikiData {

--- a/code/utils/export.ts
+++ b/code/utils/export.ts
@@ -117,6 +117,31 @@ const generateArtifactMarkdownBody = (artifact: Artifact): string => {
                 });
                 body += '\n';
             }
+            if (charData?.motivation) {
+                body += `## Motivation & Desire\n\n${charData.motivation}\n\n`;
+            }
+            if (charData?.conflict) {
+                body += `## Core Conflict\n\n${charData.conflict}\n\n`;
+            }
+            if (charData?.secret) {
+                body += `## Secrets & Twists\n\n${charData.secret}\n\n`;
+            }
+            if (charData?.narrativeRole || charData?.arcStage || charData?.relationships) {
+                body += '## Narrative Role\n';
+                if (charData.narrativeRole) {
+                    body += `- Role: ${charData.narrativeRole}\n`;
+                }
+                if (charData.arcStage) {
+                    body += `- Arc Stage: ${charData.arcStage}\n`;
+                }
+                if (charData.relationships) {
+                    body += `- Relationships & Allies: ${charData.relationships}\n`;
+                }
+                body += '\n';
+            }
+            if (charData?.voiceNotes) {
+                body += `## Voice & Cadence\n\n${charData.voiceNotes}\n\n`;
+            }
             break;
         }
         case ArtifactType.Conlang: {
@@ -294,7 +319,35 @@ const generateArtifactContent = (artifact: Artifact, allArtifacts: Artifact[]): 
         charData.traits.forEach(trait => {
             content += `<li class='text-slate-400'><strong class='text-slate-300'>${trait.key}:</strong> ${trait.value}</li>`;
         });
-        content += '</ul></div>';
+        content += '</ul>';
+
+        if (charData.motivation) {
+            content += `<div class='mt-4'><h3 class='font-bold text-slate-200 mb-2'>Motivation &amp; Desire</h3><p class='text-slate-400 whitespace-pre-line leading-relaxed'>${charData.motivation}</p></div>`;
+        }
+        if (charData.conflict) {
+            content += `<div class='mt-4'><h3 class='font-bold text-slate-200 mb-2'>Core Conflict</h3><p class='text-slate-400 whitespace-pre-line leading-relaxed'>${charData.conflict}</p></div>`;
+        }
+        if (charData.secret) {
+            content += `<div class='mt-4'><h3 class='font-bold text-slate-200 mb-2'>Secrets &amp; Twists</h3><p class='text-slate-400 whitespace-pre-line leading-relaxed'>${charData.secret}</p></div>`;
+        }
+        if (charData.narrativeRole || charData.arcStage || charData.relationships) {
+            content += "<div class='mt-4'><h3 class='font-bold text-slate-200 mb-2'>Narrative Role</h3><ul class='list-disc list-inside space-y-1 text-slate-400'>";
+            if (charData.narrativeRole) {
+                content += `<li><strong class='text-slate-300'>Role:</strong> ${charData.narrativeRole}</li>`;
+            }
+            if (charData.arcStage) {
+                content += `<li><strong class='text-slate-300'>Arc Stage:</strong> ${charData.arcStage}</li>`;
+            }
+            if (charData.relationships) {
+                content += `<li><strong class='text-slate-300'>Relationships &amp; Allies:</strong> ${charData.relationships}</li>`;
+            }
+            content += '</ul></div>';
+        }
+        if (charData.voiceNotes) {
+            content += `<div class='mt-4'><h3 class='font-bold text-slate-200 mb-2'>Voice &amp; Cadence</h3><p class='text-slate-400 whitespace-pre-line leading-relaxed'>${charData.voiceNotes}</p></div>`;
+        }
+
+        content += '</div>';
     } else if (artifact.type === ArtifactType.Conlang) {
         const lexemes = artifact.data as ConlangLexeme[];
         if (Array.isArray(lexemes) && lexemes.length > 0) {

--- a/code/utils/import.ts
+++ b/code/utils/import.ts
@@ -29,7 +29,17 @@ const getDefaultDataForType = (type: ArtifactType): Artifact['data'] => {
         case ArtifactType.Task:
             return { state: TaskState.Todo } as TaskData;
         case ArtifactType.Character:
-            return { bio: '', traits: [] } as CharacterData;
+            return {
+                bio: '',
+                traits: [],
+                motivation: '',
+                conflict: '',
+                secret: '',
+                narrativeRole: '',
+                arcStage: '',
+                voiceNotes: '',
+                relationships: '',
+            } as CharacterData;
         case ArtifactType.Wiki:
             return { content: '' } as WikiData;
         case ArtifactType.Location:
@@ -86,6 +96,13 @@ const parseArtifactData = (type: ArtifactType, rawData?: string): Artifact['data
                     return {
                         bio: typeof character.bio === 'string' ? character.bio : '',
                         traits: Array.isArray(character.traits) ? character.traits : [],
+                        motivation: typeof character.motivation === 'string' ? character.motivation : '',
+                        conflict: typeof character.conflict === 'string' ? character.conflict : '',
+                        secret: typeof character.secret === 'string' ? character.secret : '',
+                        narrativeRole: typeof character.narrativeRole === 'string' ? character.narrativeRole : '',
+                        arcStage: typeof character.arcStage === 'string' ? character.arcStage : '',
+                        voiceNotes: typeof character.voiceNotes === 'string' ? character.voiceNotes : '',
+                        relationships: typeof character.relationships === 'string' ? character.relationships : '',
                     };
                 }
                 return getDefaultDataForType(type);

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -17,8 +17,8 @@ The “Organize My Worlds Without Pain” release.
 - [ ] Import pipelines for Markdown and text dumps (chat, drafts).
 - [ ] Export pipelines for chapter bible PDF/Markdown and lore JSON for game engines (Dustland ACK modules).
 - [ ] World dashboards to add lore, visualize connections, and link crossover projects (Dustland NPC ←→ Sacred Truth vampire cameo).
-- [ ] "Add one fact" button to reduce overwhelm.
-- [ ] "Reveal depth" toggle for simple → detailed fields.
+- [x] "Add one fact" button to reduce overwhelm.
+- [x] "Reveal depth" toggle for simple → detailed fields.
 - [ ] "Narrative need heatmap" that flags characters not seen recently.
 - [ ] Memory sync with Gemini-powered conversations gated by user approval.
 
@@ -29,7 +29,7 @@ The “Organize My Worlds Without Pain” release.
 - [ ] Level-up tree with creativity perks (Lore Weaver, Archivist, World Alchemist, Dungeon Master).
 - [ ] Collectible inspiration cards covering archetypes, vibes, visual prompts, and genre modifiers.
 - [ ] Player profile with creative streak tracking.
-- [ ] Inspiration deck draw interface for mid-writing boosts.
+- [x] Inspiration deck draw interface for mid-writing boosts.
 
 ### Phase 3 — World Simulation Layer
 "World memory and logic enforcement."


### PR DESCRIPTION
## Summary
- add an "add one fact" prompt generator to the project overview summary editor
- extend the character editor with a revealable depth panel and persist new narrative fields through import/export
- surface an inspiration deck draw experience alongside AI copilots and update the roadmap to reflect the delivered designs

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_690585fb68708328aaed37b1ea130df3