### PR TITLE
Add reveal depth toggle for advanced artifact editing

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -61,11 +61,13 @@ import MilestoneTracker from './components/MilestoneTracker';
 import ErrorBanner from './components/ErrorBanner';
 import TutorialGuide from './components/TutorialGuide';
 import ErrorBoundary from './components/ErrorBoundary';
+import RevealDepthToggle from './components/RevealDepthToggle';
 import { createProjectActivity, evaluateMilestoneProgress, MilestoneProgressOverview, ProjectActivity } from './utils/milestoneProgress';
 import InfoModal from './components/InfoModal';
 import PublishToGitHubModal from './components/PublishToGitHubModal';
 import { publishToGitHub } from './services/dataApi';
 import QuickFactForm from './components/QuickFactForm';
+import { DepthPreferencesProvider } from './contexts/DepthPreferencesContext';
 
 const countArtifactsByType = (artifacts: Artifact[], type: ArtifactType) =>
   artifacts.filter((artifact) => artifact.type === type).length;
@@ -1638,7 +1640,8 @@ export default function App() {
   );
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <DepthPreferencesProvider>
+      <div className="min-h-screen flex flex-col">
       {isTutorialVisible && <ErrorBoundary><TutorialGuide /></ErrorBoundary>}
       <Header profile={profile} xpProgress={xpProgress} level={level} onSignOut={signOutUser} onStartTutorial={() => setIsTutorialVisible(true)} />
       {error && (
@@ -1805,8 +1808,11 @@ export default function App() {
                             </button>
                         )}
                     </div>
-                    <div className="text-xs text-slate-400">
-                        Showing <span className="text-slate-200 font-semibold">{filteredArtifacts.length}</span> of <span className="text-slate-200 font-semibold">{projectArtifacts.length}</span> artifacts
+                    <div className="flex flex-col items-start gap-3 text-xs text-slate-400 sm:flex-row sm:items-center sm:gap-4">
+                        <RevealDepthToggle />
+                        <span>
+                            Showing <span className="text-slate-200 font-semibold">{filteredArtifacts.length}</span> of <span className="text-slate-200 font-semibold">{projectArtifacts.length}</span> artifacts
+                        </span>
                     </div>
                 </div>
                 {viewMode === 'table' && (
@@ -2048,6 +2054,7 @@ export default function App() {
         onPublish={handlePublishToGithubRepo}
         isPublishing={isPublishing}
       />
-    </div>
+      </div>
+    </DepthPreferencesProvider>
   );
 }

--- a/code/components/ArtifactDetail.tsx
+++ b/code/components/ArtifactDetail.tsx
@@ -4,6 +4,7 @@ import { expandSummary } from '../services/geminiService';
 import { exportArtifactToMarkdown } from '../utils/export';
 import { getStatusClasses, formatStatusLabel } from '../utils/status';
 import { SparklesIcon, Spinner, LinkIcon, PlusIcon, ArrowDownTrayIcon, XMarkIcon, ChevronDownIcon } from './Icons';
+import { useDepthPreferences } from '../contexts/DepthPreferencesContext';
 
 interface ArtifactDetailProps {
   artifact: Artifact;
@@ -35,6 +36,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
   const [isEditingSummary, setIsEditingSummary] = useState(false);
   const [tagInput, setTagInput] = useState('');
   const [showActions, setShowActions] = useState(false);
+  const { showDetailedFields } = useDepthPreferences();
 
   useEffect(() => {
     setEditableSummary(artifact.summary);
@@ -44,6 +46,14 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
     setRelationTargetId('');
     setRelationKind('RELATES_TO');
   }, [artifact.id, artifact.summary]);
+
+  useEffect(() => {
+    if (!showDetailedFields) {
+      setShowAddRelation(false);
+      setIsEditingSummary(false);
+      setShowActions(false);
+    }
+  }, [showDetailedFields]);
 
   const statusOptions = Array.from(
     new Set([artifact.status, ...BASE_STATUS_OPTIONS].filter((status): status is string => Boolean(status)))
@@ -144,43 +154,45 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
             </div>
             <p className="text-sm text-slate-400 mt-2">Type: <span className="font-semibold text-cyan-400">{artifact.type}</span></p>
           </div>
-          <div className="relative">
-            <button
-              onClick={() => setShowActions(!showActions)}
-              className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-md transition-colors"
-            >
-              Actions <ChevronDownIcon className="w-4 h-4" />
-            </button>
-            {showActions && (
-              <div className="absolute top-full right-0 mt-2 w-48 bg-slate-800 border border-slate-700 rounded-md shadow-lg z-10">
-                <button
-                  onClick={() => {
-                    exportArtifactToMarkdown(artifact);
-                    setShowActions(false);
-                  }}
-                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-slate-300 hover:bg-slate-700"
-                >
-                  <ArrowDownTrayIcon className="w-4 h-4" /> Export .md
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const confirmed = window.confirm(
-                      `Delete artifact "${artifact.title}"? This cannot be undone.`,
-                    );
-                    if (!confirmed) {
-                      return;
-                    }
-                    void onDeleteArtifact(artifact.id);
-                    setShowActions(false);
-                  }}
-                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-rose-400 hover:bg-rose-500/20"
-                >
-                  <XMarkIcon className="w-4 h-4" /> Delete
-                </button>
-              </div>
-            )}
-          </div>
+          {showDetailedFields && (
+            <div className="relative">
+              <button
+                onClick={() => setShowActions(!showActions)}
+                className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-md transition-colors"
+              >
+                Actions <ChevronDownIcon className="w-4 h-4" />
+              </button>
+              {showActions && (
+                <div className="absolute top-full right-0 mt-2 w-48 bg-slate-800 border border-slate-700 rounded-md shadow-lg z-10">
+                  <button
+                    onClick={() => {
+                      exportArtifactToMarkdown(artifact);
+                      setShowActions(false);
+                    }}
+                    className="flex items-center gap-2 w-full px-3 py-2 text-sm text-slate-300 hover:bg-slate-700"
+                  >
+                    <ArrowDownTrayIcon className="w-4 h-4" /> Export .md
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const confirmed = window.confirm(
+                        `Delete artifact "${artifact.title}"? This cannot be undone.`,
+                      );
+                      if (!confirmed) {
+                        return;
+                      }
+                      void onDeleteArtifact(artifact.id);
+                      setShowActions(false);
+                    }}
+                    className="flex items-center gap-2 w-full px-3 py-2 text-sm text-rose-400 hover:bg-rose-500/20"
+                  >
+                    <XMarkIcon className="w-4 h-4" /> Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -188,18 +200,24 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
             <label htmlFor="artifact-status" className="block text-xs font-semibold text-slate-400 uppercase tracking-wide mb-1">
               Stage
             </label>
-            <select
-              id="artifact-status"
-              value={artifact.status}
-              onChange={handleStatusChange}
-              className="w-full bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            >
-              {statusOptions.map((status) => (
-                <option key={status} value={status}>
-                  {formatStatusLabel(status)}
-                </option>
-              ))}
-            </select>
+            {showDetailedFields ? (
+              <select
+                id="artifact-status"
+                value={artifact.status}
+                onChange={handleStatusChange}
+                className="w-full bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+              >
+                {statusOptions.map((status) => (
+                  <option key={status} value={status}>
+                    {formatStatusLabel(status)}
+                  </option>
+                ))}
+              </select>
+            ) : (
+              <div className="w-full rounded-md border border-slate-700/60 bg-slate-800/40 px-3 py-2 text-sm font-semibold text-slate-200">
+                {formatStatusLabel(artifact.status)}
+              </div>
+            )}
           </div>
 
           <div className="md:col-span-2">
@@ -211,50 +229,60 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
                   className="inline-flex items-center gap-1 px-2 py-1 text-xs font-medium bg-slate-700/60 border border-slate-600/60 rounded-full text-slate-200"
                 >
                   {tag}
-                  <button
-                    onClick={() => handleRemoveTag(tag)}
-                    className="text-slate-400 hover:text-red-400"
-                    aria-label={`Remove tag ${tag}`}
-                  >
-                    <XMarkIcon className="w-3 h-3" />
-                  </button>
+                  {showDetailedFields && (
+                    <button
+                      onClick={() => handleRemoveTag(tag)}
+                      className="text-slate-400 hover:text-red-400"
+                      aria-label={`Remove tag ${tag}`}
+                    >
+                      <XMarkIcon className="w-3 h-3" />
+                    </button>
+                  )}
                 </span>
               ))}
               {artifact.tags.length === 0 && (
-                <span className="text-xs text-slate-500">No tags yet. Add one below to categorize this artifact.</span>
+                <span className="text-xs text-slate-500">
+                  {showDetailedFields ? 'No tags yet. Add one below to categorize this artifact.' : 'No tags yet. Reveal depth to start organizing with tags.'}
+                </span>
               )}
             </div>
-            <div className="flex items-center gap-2">
-              <input
-                id="artifact-tags-input"
-                type="text"
-                value={tagInput}
-                onChange={(event) => setTagInput(event.target.value)}
-                onKeyDown={handleTagKeyDown}
-                placeholder="Add tag and press Enter"
-                className="flex-grow bg-slate-800 border border-slate-600 rounded-md px-3 py-2 text-slate-200 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-              />
-              <button
-                onClick={handleAddTag}
-                className="inline-flex items-center gap-1 px-3 py-2 text-xs font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors"
-              >
-                <PlusIcon className="w-4 h-4" /> Add
-              </button>
-            </div>
+            {showDetailedFields ? (
+              <div className="flex items-center gap-2">
+                <input
+                  id="artifact-tags-input"
+                  type="text"
+                  value={tagInput}
+                  onChange={(event) => setTagInput(event.target.value)}
+                  onKeyDown={handleTagKeyDown}
+                  placeholder="Add tag and press Enter"
+                  className="flex-grow bg-slate-800 border border-slate-600 rounded-md px-3 py-2 text-slate-200 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+                />
+                <button
+                  onClick={handleAddTag}
+                  className="inline-flex items-center gap-1 px-3 py-2 text-xs font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors"
+                >
+                  <PlusIcon className="w-4 h-4" /> Add
+                </button>
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">Reveal depth to add or edit tags.</p>
+            )}
           </div>
         </div>
 
         <div>
           <div className="flex items-center justify-between mb-2">
             <label htmlFor="artifact-summary" className="text-xs font-semibold text-slate-400 uppercase tracking-wide">Summary</label>
-            <div className="flex items-center gap-2">
-              <button
-                onClick={() => (isEditingSummary ? handleCancelSummary() : setIsEditingSummary(true))}
-                className="text-xs font-semibold text-cyan-300 hover:text-cyan-200"
-              >
-                {isEditingSummary ? 'Cancel' : 'Edit'}
-              </button>
-            </div>
+            {showDetailedFields && (
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => (isEditingSummary ? handleCancelSummary() : setIsEditingSummary(true))}
+                  className="text-xs font-semibold text-cyan-300 hover:text-cyan-200"
+                >
+                  {isEditingSummary ? 'Cancel' : 'Edit'}
+                </button>
+              </div>
+            )}
           </div>
           {isEditingSummary ? (
             <>
@@ -285,17 +313,19 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
               {artifact.summary || <span className="text-slate-500">No summary yet. Use Lore Weaver to spin one up.</span>}
             </div>
           )}
-          <div className="flex items-center gap-2 mt-4">
-            <button
-              onClick={handleExpandSummary}
-              disabled={isExpanding || isEditingSummary}
-              className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-white bg-violet-600 hover:bg-violet-500 rounded-md transition-colors disabled:bg-slate-600"
-            >
-              {isExpanding ? <Spinner className="w-4 h-4" /> : <SparklesIcon className="w-4 h-4" />}
-              Lore Weaver: Expand Summary
-            </button>
-            {expandError && <p className="text-red-400 text-xs">{expandError}</p>}
-          </div>
+          {showDetailedFields && (
+            <div className="flex items-center gap-2 mt-4">
+              <button
+                onClick={handleExpandSummary}
+                disabled={isExpanding || isEditingSummary}
+                className="flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-white bg-violet-600 hover:bg-violet-500 rounded-md transition-colors disabled:bg-slate-600"
+              >
+                {isExpanding ? <Spinner className="w-4 h-4" /> : <SparklesIcon className="w-4 h-4" />}
+                Lore Weaver: Expand Summary
+              </button>
+              {expandError && <p className="text-red-400 text-xs">{expandError}</p>}
+            </div>
+          )}
         </div>
       </div>
 
@@ -303,67 +333,90 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
         <h4 className="font-semibold text-slate-200 mb-3 flex items-center gap-2">
           <LinkIcon className="w-5 h-5 text-slate-400" /> Relations
         </h4>
-        <div className="space-y-2">
-          {artifact.relations.map((rel, index) => {
-            const target = projectArtifacts.find((a) => a.id === rel.toId);
-            return (
-              <div key={`${rel.toId}-${index}`} className="flex items-center gap-2 text-sm bg-slate-700/50 px-3 py-1.5 rounded-md">
-                <span className="text-slate-400">{formatStatusLabel(rel.kind)}</span>
-                <span className="font-semibold text-cyan-300">{target?.title || 'Unknown Artifact'}</span>
-                <button
-                  onClick={() => handleRemoveRelation(index)}
-                  className="ml-auto p-1 text-slate-400 hover:text-red-400"
-                  aria-label={`Remove relation ${rel.kind} to ${target?.title ?? rel.toId}`}
+        {showDetailedFields ? (
+          <>
+            <div className="space-y-2">
+              {artifact.relations.map((rel, index) => {
+                const target = projectArtifacts.find((a) => a.id === rel.toId);
+                return (
+                  <div key={`${rel.toId}-${index}`} className="flex items-center gap-2 text-sm bg-slate-700/50 px-3 py-1.5 rounded-md">
+                    <span className="text-slate-400">{formatStatusLabel(rel.kind)}</span>
+                    <span className="font-semibold text-cyan-300">{target?.title || 'Unknown Artifact'}</span>
+                    <button
+                      onClick={() => handleRemoveRelation(index)}
+                      className="ml-auto p-1 text-slate-400 hover:text-red-400"
+                      aria-label={`Remove relation ${rel.kind} to ${target?.title ?? rel.toId}`}
+                    >
+                      <XMarkIcon className="w-4 h-4" />
+                    </button>
+                  </div>
+                );
+              })}
+              {artifact.relations.length === 0 && !showAddRelation && (
+                <p className="text-sm text-slate-500">No relations yet.</p>
+              )}
+            </div>
+
+            {showAddRelation ? (
+              <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 mt-4">
+                <select
+                  value={relationKind}
+                  onChange={(event) => setRelationKind(event.target.value)}
+                  className="w-full sm:w-40 bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
                 >
-                  <XMarkIcon className="w-4 h-4" />
+                  {relationOptions.map((option) => (
+                    <option key={option} value={option}>
+                      {formatStatusLabel(option)}
+                    </option>
+                  ))}
+                </select>
+                <select
+                  value={relationTargetId}
+                  onChange={(event) => setRelationTargetId(event.target.value)}
+                  className="w-full bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
+                >
+                  <option value="">Select an artifact to link...</option>
+                  {availableTargets.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {a.title} ({a.type})
+                    </option>
+                  ))}
+                </select>
+                <button
+                  onClick={handleAddRelationClick}
+                  className="px-4 py-2 text-sm font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors"
+                >
+                  Link
                 </button>
               </div>
-            );
-          })}
-          {artifact.relations.length === 0 && !showAddRelation && (
-            <p className="text-sm text-slate-500">No relations yet.</p>
-          )}
-        </div>
-
-        {showAddRelation ? (
-          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2 mt-4">
-            <select
-              value={relationKind}
-              onChange={(event) => setRelationKind(event.target.value)}
-              className="w-full sm:w-40 bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            >
-              {relationOptions.map((option) => (
-                <option key={option} value={option}>
-                  {formatStatusLabel(option)}
-                </option>
-              ))}
-            </select>
-            <select
-              value={relationTargetId}
-              onChange={(event) => setRelationTargetId(event.target.value)}
-              className="w-full bg-slate-700 border border-slate-600 rounded-md px-3 py-2 text-slate-100 focus:ring-2 focus:ring-cyan-500 focus:border-cyan-500 transition"
-            >
-              <option value="">Select an artifact to link...</option>
-              {availableTargets.map((a) => (
-                <option key={a.id} value={a.id}>
-                  {a.title} ({a.type})
-                </option>
-              ))}
-            </select>
-            <button
-              onClick={handleAddRelationClick}
-              className="px-4 py-2 text-sm font-semibold text-white bg-cyan-600 hover:bg-cyan-500 rounded-md transition-colors"
-            >
-              Link
-            </button>
-          </div>
+            ) : (
+              <button
+                onClick={() => setShowAddRelation(true)}
+                className="mt-4 flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-md transition-colors"
+              >
+                <PlusIcon className="w-4 h-4" /> Add Relation
+              </button>
+            )}
+          </>
         ) : (
-          <button
-            onClick={() => setShowAddRelation(true)}
-            className="mt-4 flex items-center gap-2 px-3 py-1.5 text-xs font-semibold text-slate-300 bg-slate-700 hover:bg-slate-600 rounded-md transition-colors"
-          >
-            <PlusIcon className="w-4 h-4" /> Add Relation
-          </button>
+          <div className="space-y-3 text-sm text-slate-400">
+            {artifact.relations.length > 0 ? (
+              <ul className="space-y-2">
+                {artifact.relations.map((rel, index) => {
+                  const target = projectArtifacts.find((a) => a.id === rel.toId);
+                  return (
+                    <li key={`${rel.toId}-${index}`} className="rounded-md border border-slate-700/60 bg-slate-800/40 px-3 py-2">
+                      <span className="font-semibold text-cyan-300">{target?.title || 'Unknown Artifact'}</span>
+                      <span className="ml-2 text-xs uppercase tracking-wide text-slate-500">{formatStatusLabel(rel.kind)}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="text-xs text-slate-500">No relations yet. Reveal depth to start weaving connections.</p>
+            )}
+            <p className="text-xs text-slate-500">Detailed linking tools appear when you reveal depth.</p>
+          </div>
         )}
       </div>
     </div>

--- a/code/components/CharacterEditor.tsx
+++ b/code/components/CharacterEditor.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Artifact, ArtifactType, CharacterData, CharacterTrait, NARRATIVE_ARTIFACT_TYPES } from '../types';
 import { PlusIcon, XMarkIcon, UserCircleIcon } from './Icons';
 import EditorRelationSidebar from './EditorRelationSidebar';
+import { useDepthPreferences } from '../contexts/DepthPreferencesContext';
 
 const CHARACTER_APPEARS_IN_TYPES: ArtifactType[] = [
   ...NARRATIVE_ARTIFACT_TYPES,
@@ -36,6 +37,7 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({
   const [traits, setTraits] = useState<CharacterTrait[]>(data.traits);
   const [newTraitKey, setNewTraitKey] = useState('');
   const [newTraitValue, setNewTraitValue] = useState('');
+  const { showDetailedFields } = useDepthPreferences();
 
   const handleUpdate = (updatedData: Partial<CharacterData>) => {
     onUpdateArtifactData(artifact.id, { ...data, ...updatedData });
@@ -95,36 +97,44 @@ const CharacterEditor: React.FC<CharacterEditorProps> = ({
                 <div key={trait.id} className="flex items-center gap-2 bg-slate-700/50 p-2 rounded-md">
                   <strong className="text-slate-300 text-sm">{trait.key}:</strong>
                   <span className="text-slate-400 text-sm flex-grow">{trait.value}</span>
-                  <button onClick={() => handleDeleteTrait(trait.id)} className="p-1 text-slate-500 hover:text-red-400">
-                    <XMarkIcon className="w-4 h-4" />
-                  </button>
+                  {showDetailedFields && (
+                    <button onClick={() => handleDeleteTrait(trait.id)} className="p-1 text-slate-500 hover:text-red-400">
+                      <XMarkIcon className="w-4 h-4" />
+                    </button>
+                  )}
                 </div>
               ))}
               {traits.length === 0 && (
                 <p className="text-xs text-slate-500 bg-slate-900/50 border border-dashed border-slate-700/60 rounded-md px-3 py-2">
-                  No signature traits yet. Capture quirks, bonds, or stats to bring them to life.
+                  {showDetailedFields
+                    ? 'No signature traits yet. Capture quirks, bonds, or stats to bring them to life.'
+                    : 'No signature traits yet. Reveal depth to start tracking quirks and bonds.'}
                 </p>
               )}
             </div>
-            <div className="space-y-2 p-3 bg-slate-900/50 rounded-md border border-slate-700">
-              <input
-                type="text"
-                value={newTraitKey}
-                onChange={e => setNewTraitKey(e.target.value)}
-                placeholder="Trait (e.g., Age)"
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
-              />
-              <input
-                type="text"
-                value={newTraitValue}
-                onChange={e => setNewTraitValue(e.target.value)}
-                placeholder="Value (e.g., 27)"
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
-              />
-              <button onClick={handleAddTrait} className="w-full flex items-center justify-center gap-1 px-3 py-1 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-500 rounded-md transition-colors">
-                <PlusIcon className="w-4 h-4" /> Add Trait
-              </button>
-            </div>
+            {showDetailedFields ? (
+              <div className="space-y-2 p-3 bg-slate-900/50 rounded-md border border-slate-700">
+                <input
+                  type="text"
+                  value={newTraitKey}
+                  onChange={e => setNewTraitKey(e.target.value)}
+                  placeholder="Trait (e.g., Age)"
+                  className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
+                />
+                <input
+                  type="text"
+                  value={newTraitValue}
+                  onChange={e => setNewTraitValue(e.target.value)}
+                  placeholder="Value (e.g., 27)"
+                  className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-blue-500"
+                />
+                <button onClick={handleAddTrait} className="w-full flex items-center justify-center gap-1 px-3 py-1 text-sm font-semibold text-white bg-blue-600 hover:bg-blue-500 rounded-md transition-colors">
+                  <PlusIcon className="w-4 h-4" /> Add Trait
+                </button>
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">Reveal depth to add or adjust character traits.</p>
+            )}
           </div>
         </div>
 

--- a/code/components/LocationEditor.tsx
+++ b/code/components/LocationEditor.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Artifact, ArtifactType, LocationData, LocationFeature, NARRATIVE_ARTIFACT_TYPES } from '../types';
 import { PlusIcon, XMarkIcon, MapPinIcon } from './Icons';
 import EditorRelationSidebar from './EditorRelationSidebar';
+import { useDepthPreferences } from '../contexts/DepthPreferencesContext';
 
 const LOCATION_APPEARANCE_TYPES: ArtifactType[] = [
   ...NARRATIVE_ARTIFACT_TYPES,
@@ -33,6 +34,7 @@ const LocationEditor: React.FC<LocationEditorProps> = ({
   const [features, setFeatures] = useState<LocationFeature[]>(data.features);
   const [newFeatureName, setNewFeatureName] = useState('');
   const [newFeatureDesc, setNewFeatureDesc] = useState('');
+  const { showDetailedFields } = useDepthPreferences();
 
   const handleUpdate = (updatedData: Partial<LocationData>) => {
     onUpdateArtifactData(artifact.id, { ...data, ...updatedData });
@@ -92,36 +94,44 @@ const LocationEditor: React.FC<LocationEditorProps> = ({
                 <div key={feature.id} className="bg-slate-700/50 p-2 rounded-md relative group">
                   <strong className="text-slate-300 text-sm">{feature.name}</strong>
                   <p className="text-slate-400 text-xs">{feature.description}</p>
-                  <button onClick={() => handleDeleteFeature(feature.id)} className="absolute top-1 right-1 p-1 text-slate-500 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <XMarkIcon className="w-4 h-4" />
-                  </button>
+                  {showDetailedFields && (
+                    <button onClick={() => handleDeleteFeature(feature.id)} className="absolute top-1 right-1 p-1 text-slate-500 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-opacity">
+                      <XMarkIcon className="w-4 h-4" />
+                    </button>
+                  )}
                 </div>
               ))}
               {features.length === 0 && (
                 <p className="text-xs text-slate-500 bg-slate-900/50 border border-dashed border-slate-700/60 rounded-md px-3 py-2">
-                  No features yet. Map districts, landmarks, or sensory details to anchor the space.
+                  {showDetailedFields
+                    ? 'No features yet. Map districts, landmarks, or sensory details to anchor the space.'
+                    : 'No features yet. Reveal depth to start charting landmarks and sensory details.'}
                 </p>
               )}
             </div>
-            <div className="space-y-2 p-3 bg-slate-900/50 rounded-md border border-slate-700">
-              <input
-                type="text"
-                value={newFeatureName}
-                onChange={e => setNewFeatureName(e.target.value)}
-                placeholder="Feature Name"
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-violet-500"
-              />
-              <input
-                type="text"
-                value={newFeatureDesc}
-                onChange={e => setNewFeatureDesc(e.target.value)}
-                placeholder="Brief description"
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-violet-500"
-              />
-              <button onClick={handleAddFeature} className="w-full flex items-center justify-center gap-1 px-3 py-1 text-sm font-semibold text-white bg-violet-600 hover:bg-violet-500 rounded-md transition-colors">
-                <PlusIcon className="w-4 h-4" /> Add Feature
-              </button>
-            </div>
+            {showDetailedFields ? (
+              <div className="space-y-2 p-3 bg-slate-900/50 rounded-md border border-slate-700">
+                <input
+                  type="text"
+                  value={newFeatureName}
+                  onChange={e => setNewFeatureName(e.target.value)}
+                  placeholder="Feature Name"
+                  className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-violet-500"
+                />
+                <input
+                  type="text"
+                  value={newFeatureDesc}
+                  onChange={e => setNewFeatureDesc(e.target.value)}
+                  placeholder="Brief description"
+                  className="w-full bg-slate-800 border border-slate-600 rounded-md px-2 py-1 text-sm text-slate-200 focus:ring-1 focus:ring-violet-500"
+                />
+                <button onClick={handleAddFeature} className="w-full flex items-center justify-center gap-1 px-3 py-1 text-sm font-semibold text-white bg-violet-600 hover:bg-violet-500 rounded-md transition-colors">
+                  <PlusIcon className="w-4 h-4" /> Add Feature
+                </button>
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">Reveal depth to add or adjust notable features.</p>
+            )}
           </div>
         </div>
 

--- a/code/components/RevealDepthToggle.tsx
+++ b/code/components/RevealDepthToggle.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { TriangleToggleIcon, SparklesIcon } from './Icons';
+import { useDepthPreferences } from '../contexts/DepthPreferencesContext';
+
+const RevealDepthToggle: React.FC = () => {
+  const { showDetailedFields, toggleDetailedFields } = useDepthPreferences();
+
+  return (
+    <div className="inline-flex items-center gap-3 rounded-full border border-slate-700/70 bg-slate-900/50 px-4 py-2 text-slate-200 shadow-inner shadow-slate-900/40">
+      <div className="flex flex-col">
+        <span className="text-[10px] font-semibold uppercase tracking-wide text-slate-400">Detail Level</span>
+        <span className="text-xs text-slate-200">{showDetailedFields ? 'Detailed fields revealed' : 'Simple fields only'}</span>
+      </div>
+      <button
+        type="button"
+        onClick={toggleDetailedFields}
+        aria-pressed={showDetailedFields}
+        className={`relative flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-semibold transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400 ${
+          showDetailedFields ? 'bg-cyan-600 text-white hover:bg-cyan-500' : 'bg-slate-800 text-slate-200 hover:bg-slate-700'
+        }`}
+      >
+        <TriangleToggleIcon className={`h-3 w-6 transition-transform ${showDetailedFields ? 'rotate-180 text-white' : 'text-cyan-300'}`} />
+        {showDetailedFields ? (
+          <span className="flex items-center gap-1">
+            <SparklesIcon className="h-3.5 w-3.5" /> Detailed View
+          </span>
+        ) : (
+          <span>Reveal Depth</span>
+        )}
+      </button>
+    </div>
+  );
+};
+
+export default RevealDepthToggle;
+

--- a/code/components/StoryEditor.tsx
+++ b/code/components/StoryEditor.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Artifact, ArtifactType, Scene, NARRATIVE_ARTIFACT_TYPES } from '../types';
 import { PlusIcon, XMarkIcon } from './Icons';
 import EditorRelationSidebar from './EditorRelationSidebar';
+import { useDepthPreferences } from '../contexts/DepthPreferencesContext';
 
 const CAST_TARGET_TYPES: ArtifactType[] = [ArtifactType.Character, ArtifactType.Faction];
 const STORY_SUPPORT_TYPES: ArtifactType[] = [
@@ -36,6 +37,7 @@ const StoryEditor: React.FC<StoryEditorProps> = ({
   const scenes = (artifact.data as Scene[]) || [];
   const [newSceneTitle, setNewSceneTitle] = useState('');
   const [newSceneSummary, setNewSceneSummary] = useState('');
+  const { showDetailedFields } = useDepthPreferences();
 
   const handleAddScene = () => {
     if (!newSceneTitle.trim()) return;
@@ -64,41 +66,47 @@ const StoryEditor: React.FC<StoryEditorProps> = ({
           <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
             {scenes.map(scene => (
               <div key={scene.id} className="bg-slate-700/50 rounded-lg p-4 border border-slate-600/80 relative group">
-                <button
-                  onClick={() => handleDeleteScene(scene.id)}
-                  className="absolute top-2 right-2 p-1 bg-slate-800/50 rounded-full text-slate-400 hover:bg-red-500/50 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
-                  aria-label="Delete scene"
-                >
-                  <XMarkIcon className="w-4 h-4" />
-                </button>
+                {showDetailedFields && (
+                  <button
+                    onClick={() => handleDeleteScene(scene.id)}
+                    className="absolute top-2 right-2 p-1 bg-slate-800/50 rounded-full text-slate-400 hover:bg-red-500/50 hover:text-white opacity-0 group-hover:opacity-100 transition-opacity"
+                    aria-label="Delete scene"
+                  >
+                    <XMarkIcon className="w-4 h-4" />
+                  </button>
+                )}
                 <h4 className="font-bold text-slate-200 mb-1">{scene.title}</h4>
                 <p className="text-sm text-slate-400">{scene.summary}</p>
               </div>
             ))}
 
-            <div className="bg-slate-900/50 rounded-lg p-4 border-2 border-dashed border-slate-700 flex flex-col gap-3">
-              <input
-                type="text"
-                value={newSceneTitle}
-                onChange={e => setNewSceneTitle(e.target.value)}
-                placeholder="New Scene Title"
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-3 py-2 text-slate-200 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 transition"
-              />
-              <textarea
-                value={newSceneSummary}
-                onChange={e => setNewSceneSummary(e.target.value)}
-                placeholder="Brief summary..."
-                rows={2}
-                className="w-full bg-slate-800 border border-slate-600 rounded-md px-3 py-2 text-slate-200 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 transition"
-              />
-              <button
-                onClick={handleAddScene}
-                className="flex items-center justify-center gap-2 w-full px-4 py-2 text-sm font-semibold text-white bg-teal-600 hover:bg-teal-500 rounded-md transition-colors"
-              >
-                <PlusIcon className="w-5 h-5" />
-                Add Scene
-              </button>
-            </div>
+            {showDetailedFields ? (
+              <div className="bg-slate-900/50 rounded-lg p-4 border-2 border-dashed border-slate-700 flex flex-col gap-3">
+                <input
+                  type="text"
+                  value={newSceneTitle}
+                  onChange={e => setNewSceneTitle(e.target.value)}
+                  placeholder="New Scene Title"
+                  className="w-full bg-slate-800 border border-slate-600 rounded-md px-3 py-2 text-slate-200 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 transition"
+                />
+                <textarea
+                  value={newSceneSummary}
+                  onChange={e => setNewSceneSummary(e.target.value)}
+                  placeholder="Brief summary..."
+                  rows={2}
+                  className="w-full bg-slate-800 border border-slate-600 rounded-md px-3 py-2 text-slate-200 focus:ring-2 focus:ring-teal-500 focus:border-teal-500 transition"
+                />
+                <button
+                  onClick={handleAddScene}
+                  className="flex items-center justify-center gap-2 w-full px-4 py-2 text-sm font-semibold text-white bg-teal-600 hover:bg-teal-500 rounded-md transition-colors"
+                >
+                  <PlusIcon className="w-5 h-5" />
+                  Add Scene
+                </button>
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">Reveal depth to draft new scenes or reorder the story.</p>
+            )}
           </div>
         </div>
 

--- a/code/contexts/DepthPreferencesContext.tsx
+++ b/code/contexts/DepthPreferencesContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useMemo, useState } from 'react';
+
+interface DepthPreferencesContextValue {
+  showDetailedFields: boolean;
+  toggleDetailedFields: () => void;
+  setShowDetailedFields: (value: boolean) => void;
+}
+
+const DepthPreferencesContext = createContext<DepthPreferencesContextValue | undefined>(undefined);
+
+interface DepthPreferencesProviderProps {
+  children: React.ReactNode;
+}
+
+export const DepthPreferencesProvider: React.FC<DepthPreferencesProviderProps> = ({ children }) => {
+  const [showDetailedFields, setShowDetailedFields] = useState(false);
+
+  const value = useMemo<DepthPreferencesContextValue>(() => ({
+    showDetailedFields,
+    toggleDetailedFields: () => setShowDetailedFields((previous) => !previous),
+    setShowDetailedFields,
+  }), [showDetailedFields]);
+
+  return <DepthPreferencesContext.Provider value={value}>{children}</DepthPreferencesContext.Provider>;
+};
+
+export const useDepthPreferences = (): DepthPreferencesContextValue => {
+  const context = useContext(DepthPreferencesContext);
+  if (!context) {
+    throw new Error('useDepthPreferences must be used within a DepthPreferencesProvider');
+  }
+  return context;
+};
+

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -18,7 +18,7 @@ The “Organize My Worlds Without Pain” release.
 - [ ] Export pipelines for chapter bible PDF/Markdown and lore JSON for game engines (Dustland ACK modules).
 - [x] "Add one fact" button to reduce overwhelm.
 - [x] World dashboards to add lore, visualize connections, and link crossover projects (Dustland NPC ←→ Sacred Truth vampire cameo).
-- [ ] - [ ] "Reveal depth" toggle for simple → detailed fields.
+- [x] "Reveal depth" toggle for simple → detailed fields.
 - [ ] "Narrative need heatmap" that flags characters not seen recently.
 - [ ] Memory sync with Gemini-powered conversations gated by user approval.
 


### PR DESCRIPTION
## Summary
- add a depth preferences context and reveal depth toggle to let users switch between simple and detailed fields
- hide advanced editing controls across artifact detail and editor sidebars until the detailed view is enabled
- mark the roadmap item for the reveal depth toggle as complete

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_69058bdc51d083288321d5a4ca0f6218