### PR TITLE
Add artifact duplication shortcut

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -172,6 +172,34 @@ const createQuickFactContent = (title: string, fact: string, detail?: string): s
   return content.endsWith('\n') ? content : `${content}\n`;
 };
 
+const cloneArtifactData = (data: Artifact['data']) => {
+  if (data === undefined) {
+    return undefined;
+  }
+
+  const structuredCloneFn = (globalThis as { structuredClone?: <T>(value: T) => T }).structuredClone;
+  if (typeof structuredCloneFn === 'function') {
+    try {
+      return structuredCloneFn(data) as Artifact['data'];
+    } catch (error) {
+      console.warn('Structured clone failed for artifact data, falling back to JSON clone.', error);
+    }
+  }
+
+  try {
+    return JSON.parse(JSON.stringify(data)) as Artifact['data'];
+  } catch (error) {
+    console.warn('JSON clone failed for artifact data, returning shallow copy instead.', error);
+    if (Array.isArray(data)) {
+      return data.map((item) => (typeof item === 'object' && item !== null ? { ...item } : item)) as Artifact['data'];
+    }
+    if (typeof data === 'object' && data !== null) {
+      return { ...data } as Artifact['data'];
+    }
+    return data;
+  }
+};
+
 const DAILY_QUESTS_PER_DAY = 4;
 
 const DAILY_QUEST_POOL: Quest[] = [
@@ -1157,6 +1185,67 @@ export default function App() {
     [deleteArtifact],
   );
 
+  const handleDuplicateArtifact = useCallback(
+    async (artifactId: string) => {
+      if (!selectedProjectId) {
+        alert('Select a project before duplicating an artifact.');
+        return;
+      }
+
+      const source = projectArtifacts.find((artifact) => artifact.id === artifactId);
+      if (!source) {
+        alert('We could not find the artifact to duplicate.');
+        return;
+      }
+
+      const existingTitles = new Set(projectArtifacts.map((artifact) => artifact.title.toLowerCase()));
+      const trimmedSourceTitle = source.title.trim();
+      const baseTitle = trimmedSourceTitle.length > 0 ? `${trimmedSourceTitle} (copy)` : 'Untitled artifact (copy)';
+      let candidateTitle = baseTitle;
+      let attempt = 2;
+      while (existingTitles.has(candidateTitle.toLowerCase())) {
+        candidateTitle = `${baseTitle} ${attempt}`;
+        attempt += 1;
+      }
+
+      const clonedData = cloneArtifactData(source.data);
+      const draft: {
+        type: ArtifactType;
+        title: string;
+        summary: string;
+        status: string;
+        tags: string[];
+        relations: Relation[];
+        data?: Artifact['data'];
+      } = {
+        type: source.type,
+        title: candidateTitle,
+        summary: source.summary,
+        status: source.status,
+        tags: [...source.tags],
+        relations: [],
+      };
+
+      if (clonedData !== undefined) {
+        draft.data = clonedData;
+      }
+
+      const created = await createArtifact(selectedProjectId, draft);
+      if (!created) {
+        alert('We could not duplicate this artifact. Please try again later.');
+        return;
+      }
+
+      setSelectedArtifactId(created.id);
+      void addXp(2);
+      setInfoModalContent({
+        title: 'Artifact duplicated',
+        message: `Created ${created.title} from ${source.title}.`,
+      });
+    },
+    [selectedProjectId, projectArtifacts, createArtifact, addXp, setInfoModalContent],
+  );
+
   const handleSelectProject = (id: string) => {
     setSelectedProjectId(id);
     setSelectedArtifactId(null);
@@ -1854,6 +1943,7 @@ export default function App() {
                       onAddRelation={handleAddRelation}
                       onRemoveRelation={handleRemoveRelation}
                       onDeleteArtifact={handleDeleteArtifact}
+                      onDuplicateArtifact={handleDuplicateArtifact}
                       addXp={addXp}
                     />
                     {selectedArtifact.type === ArtifactType.Conlang && (

--- a/code/components/ArtifactDetail.tsx
+++ b/code/components/ArtifactDetail.tsx
@@ -3,7 +3,7 @@ import { Artifact } from '../types';
 import { expandSummary } from '../services/geminiService';
 import { exportArtifactToMarkdown } from '../utils/export';
 import { getStatusClasses, formatStatusLabel } from '../utils/status';
-import { SparklesIcon, Spinner, LinkIcon, PlusIcon, ArrowDownTrayIcon, XMarkIcon, ChevronDownIcon } from './Icons';
+import { SparklesIcon, Spinner, LinkIcon, PlusIcon, ArrowDownTrayIcon, XMarkIcon, ChevronDownIcon, FolderPlusIcon } from './Icons';
 
 interface ArtifactDetailProps {
   artifact: Artifact;
@@ -12,6 +12,7 @@ interface ArtifactDetailProps {
   onAddRelation: (fromId: string, toId: string, kind: string) => void;
   onRemoveRelation: (fromId: string, relationIndex: number) => void;
   onDeleteArtifact: (artifactId: string) => Promise<void> | void;
+  onDuplicateArtifact: (artifactId: string) => Promise<void> | void;
   addXp: (amount: number) => void;
 }
 
@@ -24,6 +25,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
   onAddRelation,
   onRemoveRelation,
   onDeleteArtifact,
+  onDuplicateArtifact,
   addXp,
 }) => {
   const [isExpanding, setIsExpanding] = useState(false);
@@ -161,6 +163,16 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
                   className="flex items-center gap-2 w-full px-3 py-2 text-sm text-slate-300 hover:bg-slate-700"
                 >
                   <ArrowDownTrayIcon className="w-4 h-4" /> Export .md
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    void onDuplicateArtifact(artifact.id);
+                    setShowActions(false);
+                  }}
+                  className="flex items-center gap-2 w-full px-3 py-2 text-sm text-slate-300 hover:bg-slate-700"
+                >
+                  <FolderPlusIcon className="w-4 h-4" /> Duplicate
                 </button>
                 <button
                   type="button"


### PR DESCRIPTION
## Summary
- add reusable artifact data cloning helper to support duplication
- expose a duplicate action in the artifact inspector menu
- wire the duplicate action to create a new artifact copy and surface a confirmation toast

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_69058bf8b3648328b5a0a49a3f2a5820