### PR TITLE
Add artifact duplication shortcut

### DIFF
--- a/code/components/ArtifactDetail.tsx
+++ b/code/components/ArtifactDetail.tsx
@@ -3,7 +3,7 @@ import { Artifact } from '../types';
 import { expandSummary } from '../services/geminiService';
 import { exportArtifactToMarkdown } from '../utils/export';
 import { getStatusClasses, formatStatusLabel } from '../utils/status';
-import { SparklesIcon, Spinner, LinkIcon, PlusIcon, ArrowDownTrayIcon, XMarkIcon, ChevronDownIcon } from './Icons';
+import { SparklesIcon, Spinner, LinkIcon, PlusIcon, ArrowDownTrayIcon, XMarkIcon, ChevronDownIcon, FolderPlusIcon } from './Icons';
 import { useDepthPreferences } from '../contexts/DepthPreferencesContext';
 
 interface ArtifactDetailProps {
@@ -13,6 +13,7 @@ interface ArtifactDetailProps {
   onAddRelation: (fromId: string, toId: string, kind: string) => void;
   onRemoveRelation: (fromId: string, relationIndex: number) => void;
   onDeleteArtifact: (artifactId: string) => Promise<void> | void;
+  onDuplicateArtifact: (artifactId: string) => Promise<void> | void;
   addXp: (amount: number) => void;
 }
 
@@ -25,6 +26,7 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
   onAddRelation,
   onRemoveRelation,
   onDeleteArtifact,
+  onDuplicateArtifact,
   addXp,
 }) => {
   const [isExpanding, setIsExpanding] = useState(false);
@@ -172,6 +174,16 @@ const ArtifactDetail: React.FC<ArtifactDetailProps> = ({
                     className="flex items-center gap-2 w-full px-3 py-2 text-sm text-slate-300 hover:bg-slate-700"
                   >
                     <ArrowDownTrayIcon className="w-4 h-4" /> Export .md
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      void onDuplicateArtifact(artifact.id);
+                      setShowActions(false);
+                    }}
+                    className="flex items-center gap-2 w-full px-3 py-2 text-sm text-slate-300 hover:bg-slate-700"
+                  >
+                    <FolderPlusIcon className="w-4 h-4" /> Duplicate
                   </button>
                   <button
                     type="button"


### PR DESCRIPTION
## Summary
- add a safe helper for cloning artifact data when creating duplicates
- implement an artifact duplication action in the detail panel
- wire the duplicate handler through the app so newly created copies are selected and announced

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_69058ebeb5cc83288f8b69636641eaa7