### PR TITLE
feat: improve project navigation ux

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1450,7 +1450,7 @@ export default function App() {
   };
 
   const selectedProject = useMemo(() => projects.find(p => p.id === selectedProjectId), [projects, selectedProjectId]);
-  const filteredProjects = useMemo(() => {
+  const visibleProjects = useMemo(() => {
     const normalizedQuery = projectSearchTerm.trim().toLowerCase();
 
     return projects.filter((project) => {
@@ -1476,14 +1476,15 @@ export default function App() {
     return projectArtifacts.filter(isQuickFactArtifact).slice().sort(sortQuickFactsByRecency);
   }, [projectArtifacts, selectedProjectId]);
   const quickFactPreview = useMemo(() => quickFacts.slice(0, 4), [quickFacts]);
-  const availableProjectStatuses = useMemo(
-    () => Array.from(new Set(projects.map((project) => project.status))).sort((a, b) => a.localeCompare(b)),
-    [projects],
-  );
   const hasProjectFilters = projectStatusFilter !== 'ALL' || projectSearchTerm.trim() !== '';
-  const isSelectedProjectHiddenByFilters = Boolean(
-    selectedProjectId && !filteredProjects.some((project) => project.id === selectedProjectId),
+  const selectedProjectHiddenBySidebarFilters = Boolean(
+    selectedProjectId && !visibleProjects.some((project) => project.id === selectedProjectId),
   );
+
+  const handleResetProjectFilters = useCallback(() => {
+    setProjectStatusFilter('ALL');
+    setProjectSearchTerm('');
+  }, []);
 
   const handleQuickFactSubmit = useCallback(
     async ({ fact, detail }: { fact: string; detail?: string }) => {
@@ -1735,10 +1736,13 @@ export default function App() {
                     New
                 </button>
             </div>
-            <div className="mt-3 space-y-3">
-              <div className="space-y-3 rounded-lg border border-slate-700/60 bg-slate-900/40 p-3">
-                <div className="space-y-2">
-                  <label htmlFor="project-search" className="block text-xs font-semibold uppercase tracking-wide text-slate-400">
+            <div className="space-y-4">
+              <div className="rounded-lg border border-slate-700/60 bg-slate-900/40 p-3 space-y-3">
+                <div className="space-y-1">
+                  <label
+                    htmlFor="project-search"
+                    className="text-xs font-semibold uppercase tracking-wide text-slate-400"
+                  >
                     Search
                   </label>
                   <input
@@ -1746,36 +1750,43 @@ export default function App() {
                     type="search"
                     value={projectSearchTerm}
                     onChange={(event) => setProjectSearchTerm(event.target.value)}
-                    placeholder="Title, summary, or tag"
-                    className="w-full rounded-md border border-slate-700 bg-slate-800/80 px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                    placeholder="Project name, summary, or tag"
+                    className="w-full rounded-md border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-slate-100 focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
                   />
                 </div>
-                <div className="flex flex-wrap items-center justify-between gap-3">
-                  <div className="flex items-center gap-2">
-                    <label htmlFor="project-status-filter" className="text-xs font-semibold uppercase tracking-wide text-slate-400">
-                      Stage
-                    </label>
-                    <select
-                      id="project-status-filter"
-                      value={projectStatusFilter}
-                      onChange={(event) => setProjectStatusFilter(event.target.value as 'ALL' | ProjectStatus)}
-                      className="rounded-md border border-slate-700 bg-slate-800/80 px-2 py-1 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-cyan-500"
-                    >
-                      <option value="ALL">All stages</option>
-                      {availableProjectStatuses.map((status) => (
-                        <option key={status} value={status}>
-                          {formatStatusLabel(status)}
-                        </option>
-                      ))}
-                    </select>
-                  </div>
+                <div className="space-y-1">
+                  <label
+                    htmlFor="project-status-filter"
+                    className="text-xs font-semibold uppercase tracking-wide text-slate-400"
+                  >
+                    Status
+                  </label>
+                  <select
+                    id="project-status-filter"
+                    value={projectStatusFilter}
+                    onChange={(event) =>
+                      setProjectStatusFilter(event.target.value as ProjectStatus | 'ALL')
+                    }
+                    className="w-full rounded-md border border-slate-700 bg-slate-800/70 px-3 py-2 text-sm text-slate-100 focus:border-cyan-500 focus:outline-none focus:ring-2 focus:ring-cyan-500"
+                  >
+                    <option value="ALL">All statuses</option>
+                    {Object.values(ProjectStatus).map((status) => (
+                      <option key={status} value={status}>
+                        {formatStatusLabel(status)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex items-center justify-between text-xs text-slate-400">
+                  <span>
+                    {hasProjectFilters
+                      ? `Showing ${visibleProjects.length} of ${projects.length} projects`
+                      : `${projects.length} project${projects.length === 1 ? '' : 's'} available`}
+                  </span>
                   {hasProjectFilters && (
                     <button
                       type="button"
-                      onClick={() => {
-                        setProjectSearchTerm('');
-                        setProjectStatusFilter('ALL');
-                      }}
+                      onClick={handleResetProjectFilters}
                       className="text-xs font-semibold text-cyan-300 hover:text-cyan-200"
                     >
                       Clear filters
@@ -1783,24 +1794,23 @@ export default function App() {
                   )}
                 </div>
               </div>
-              {isSelectedProjectHiddenByFilters && (
-                <div className="rounded-lg border border-amber-600/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100">
-                  The selected project is hidden by the current filters.
+
+              {selectedProjectHiddenBySidebarFilters && (
+                <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-xs text-amber-100 space-y-2">
+                  <p>The selected project is hidden by the current filters.</p>
                   <button
                     type="button"
-                    onClick={() => {
-                      setProjectSearchTerm('');
-                      setProjectStatusFilter('ALL');
-                    }}
-                    className="ml-2 font-semibold underline underline-offset-4 hover:text-amber-50"
+                    onClick={handleResetProjectFilters}
+                    className="inline-flex items-center gap-1 rounded-md border border-amber-400/40 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide text-amber-100 transition-colors hover:border-amber-300/60 hover:text-amber-50"
                   >
-                    Show all projects
+                    Show project
                   </button>
                 </div>
               )}
+
               <div className="space-y-3">
-                {filteredProjects.length > 0 ? (
-                  filteredProjects.map((project) => (
+                {visibleProjects.length > 0 ? (
+                  visibleProjects.map((project) => (
                     <ProjectCard
                       key={project.id}
                       project={project}
@@ -1809,16 +1819,18 @@ export default function App() {
                     />
                   ))
                 ) : (
-                  <p className="rounded-lg border border-slate-700/60 bg-slate-900/40 px-3 py-4 text-sm text-slate-400">
+                  <div className="rounded-lg border border-dashed border-slate-700/70 px-4 py-6 text-center text-sm text-slate-400">
                     {hasProjectFilters
-                      ? 'No projects match the current filters.'
-                      : 'No projects yet. Create your first world to begin.'}
-                  </p>
+                      ? 'No projects match the current filters. Adjust your search or clear the filters to rediscover a world.'
+                      : 'No projects yet. Start your first world to build an atlas.'}
+                  </div>
                 )}
-                {canLoadMoreProjects && (
+                {!hasProjectFilters && canLoadMoreProjects && (
                   <button
                     type="button"
-                    onClick={() => { void handleLoadMoreProjects(); }}
+                    onClick={() => {
+                      void handleLoadMoreProjects();
+                    }}
                     className="w-full px-3 py-2 text-sm font-semibold text-cyan-200 bg-cyan-950/50 hover:bg-cyan-900/60 border border-cyan-800/50 rounded-md transition-colors disabled:opacity-60 disabled:cursor-not-allowed"
                     disabled={isLoadingMoreProjects}
                   >

--- a/code/components/ProjectCard.tsx
+++ b/code/components/ProjectCard.tsx
@@ -1,36 +1,69 @@
 
 import React, { KeyboardEvent } from 'react';
 import { Project, ProjectStatus } from '../types';
+import { formatStatusLabel } from '../utils/status';
 
-const ProjectCard: React.FC<{ project: Project; onSelect: (id: string) => void; isSelected: boolean }> = ({ project, onSelect, isSelected }) => {
-    const statusColors: Record<ProjectStatus, string> = {
-        [ProjectStatus.Active]: 'bg-green-500',
-        [ProjectStatus.Idea]: 'bg-yellow-500',
-        [ProjectStatus.Paused]: 'bg-orange-500',
-        [ProjectStatus.Archived]: 'bg-slate-600',
-    };
+const statusBadgeClasses: Record<ProjectStatus, string> = {
+  [ProjectStatus.Active]: 'border-emerald-400/40 bg-emerald-500/15 text-emerald-200',
+  [ProjectStatus.Idea]: 'border-amber-400/40 bg-amber-500/15 text-amber-200',
+  [ProjectStatus.Paused]: 'border-orange-400/40 bg-orange-500/15 text-orange-200',
+  [ProjectStatus.Archived]: 'border-slate-500/40 bg-slate-600/20 text-slate-200',
+};
 
-    return (
-        <div
-            onClick={() => onSelect(project.id)}
-            className={`p-4 rounded-lg border transition-all duration-200 cursor-pointer ${isSelected ? 'bg-slate-700/50 border-cyan-500' : 'bg-slate-800 border-slate-700 hover:border-slate-600'}`}
-            role="button"
-            aria-pressed={isSelected}
-            tabIndex={0}
-            onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
-                if (event.key === 'Enter' || event.key === ' ') {
-                    event.preventDefault();
-                    onSelect(project.id);
-                }
-            }}
-        >
-            <div className="flex justify-between items-start">
-                <h3 className="font-bold text-slate-100">{project.title}</h3>
-                <span className={`w-3 h-3 rounded-full mt-1 ${statusColors[project.status]}`} title={`Status: ${project.status}`}></span>
-            </div>
-            <p className="text-sm text-slate-400 mt-1 line-clamp-2">{project.summary}</p>
+const ProjectCard: React.FC<{ project: Project; onSelect: (id: string) => void; isSelected: boolean }> = ({
+  project,
+  onSelect,
+  isSelected,
+}) => {
+  const statusLabel = formatStatusLabel(project.status);
+
+  return (
+    <div
+      onClick={() => onSelect(project.id)}
+      className={`group relative cursor-pointer rounded-lg border p-4 transition-all duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-cyan-400/70 ${
+        isSelected
+          ? 'border-cyan-400/80 bg-slate-800/70 shadow-lg shadow-cyan-500/10 ring-2 ring-cyan-500/40'
+          : 'border-slate-700/60 bg-slate-900/40 hover:border-slate-500/70 hover:bg-slate-800/50'
+      }`}
+      role="button"
+      aria-pressed={isSelected}
+      aria-label={`Select project ${project.title}`}
+      data-selected={isSelected ? 'true' : undefined}
+      tabIndex={0}
+      title={project.summary}
+      onKeyDown={(event: KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          onSelect(project.id);
+        }
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h3 className="text-base font-semibold leading-snug text-slate-100">{project.title}</h3>
+          <p className="text-xs text-slate-400 line-clamp-2">{project.summary}</p>
         </div>
-    );
+        <span
+          className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${statusBadgeClasses[project.status]}`}
+          aria-label={`Status: ${statusLabel}`}
+        >
+          {statusLabel}
+        </span>
+      </div>
+      {project.tags.length > 0 && (
+        <div className="mt-3 flex flex-wrap gap-1.5">
+          {project.tags.map((tag) => (
+            <span
+              key={tag}
+              className="inline-flex items-center rounded-full bg-slate-800/70 px-2 py-0.5 text-[10px] uppercase tracking-wide text-slate-300 transition-colors group-hover:bg-slate-700/70"
+            >
+              #{tag}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
 };
 
 export default ProjectCard;


### PR DESCRIPTION
## Summary
- add richer project filtering controls and visibility messaging in the sidebar
- ensure the selected project can be surfaced when hidden and gate load-more behind active filters
- refresh project card styling with status badges and tag pills for better scanning

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_69058f47cddc8328a2460d0fc157db41