### PR TITLE
Ensure backend tests exit after running

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,7 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "build": "tsc -p tsconfig.json",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "dependencies": {
     "@types/express-session": "^1.18.2",


### PR DESCRIPTION
## Summary
- update the backend test script to run Vitest in single-run mode so it exits in CI

## Testing
- npm test --prefix server
- npm test --prefix code
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_6905a9e05fc08328a9de5472bc6790de