### PR TITLE
Refactor task state definition to avoid initialization error

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -16,7 +16,8 @@ import {
     InspirationCard,
     Relation,
     TaskData,
-    TaskState,
+    TASK_STATE,
+    type TaskState,
     TemplateCategory,
     TemplateEntry,
     TimelineData,
@@ -86,7 +87,7 @@ const countTasksInState = (artifacts: Artifact[], state: TaskState) =>
   ).length;
 
 const getCompletedTaskCount = (artifacts: Artifact[]) =>
-  countTasksInState(artifacts, TaskState.Done);
+  countTasksInState(artifacts, TASK_STATE.Done);
 
 const getTotalRelations = (artifacts: Artifact[]) =>
   artifacts.reduce((total, artifact) => total + artifact.relations.length, 0);
@@ -266,7 +267,7 @@ const DAILY_QUEST_POOL: Quest[] = [
     id: 'daily-task-progress',
     title: 'Kick Off a Task',
     description: 'Move two tasks into progress to build momentum.',
-    isCompleted: (artifacts) => countTasksInState(artifacts, TaskState.InProgress) >= 2,
+    isCompleted: (artifacts) => countTasksInState(artifacts, TASK_STATE.InProgress) >= 2,
     xp: 9,
   },
   {
@@ -490,7 +491,7 @@ const questlines: Questline[] = [
                     artifacts.filter(
                         (artifact) =>
                             artifact.type === ArtifactType.Task &&
-                            (artifact.data as TaskData | undefined)?.state === TaskState.Done,
+                            (artifact.data as TaskData | undefined)?.state === TASK_STATE.Done,
                     ).length >= 3,
             },
             {
@@ -664,7 +665,7 @@ const projectTemplates: ProjectTemplate[] = [
                 summary: 'Track page breakdowns, lettering, and marketing beats for the next drop.',
                 status: 'in-progress',
                 tags: ['sprint', 'release'],
-                data: { state: TaskState.InProgress } as TaskData,
+                data: { state: TASK_STATE.InProgress } as TaskData,
             },
         ],
     },
@@ -732,7 +733,7 @@ const projectTemplates: ProjectTemplate[] = [
                 summary: 'Triage insights from the latest playtest into actionable follow-ups.',
                 status: 'in-progress',
                 tags: ['playtest'],
-                data: { state: TaskState.InProgress } as TaskData,
+                data: { state: TASK_STATE.InProgress } as TaskData,
             },
             {
                 title: 'Design Log',
@@ -791,7 +792,7 @@ const getDefaultDataForType = (type: ArtifactType, title?: string): Artifact['da
 
     switch (type) {
         case ArtifactType.Task:
-            return { state: TaskState.Todo } as TaskData;
+            return { state: TASK_STATE.Todo } as TaskData;
         case ArtifactType.Character:
             return { bio: '', traits: [] };
         case ArtifactType.Wiki:
@@ -1163,8 +1164,8 @@ export default function App() {
       }
       if (
         target.type === ArtifactType.Task &&
-        (data as TaskData).state === TaskState.Done &&
-        (target.data as TaskData | undefined)?.state !== TaskState.Done
+        (data as TaskData).state === TASK_STATE.Done &&
+        (target.data as TaskData | undefined)?.state !== TASK_STATE.Done
       ) {
         void addXp(8); // XP Source: close task (+8)
       }

--- a/code/components/KanbanBoard.tsx
+++ b/code/components/KanbanBoard.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Artifact, ArtifactType, TaskData, TaskState } from '../types';
+import { Artifact, ArtifactType, TaskData, TASK_STATE, TASK_STATE_VALUES, type TaskState } from '../types';
 
 interface KanbanCardProps {
   task: Artifact;
@@ -10,7 +10,7 @@ interface KanbanCardProps {
 const KanbanCard: React.FC<KanbanCardProps> = ({ task, onUpdateTaskState }) => {
   const taskData = task.data as TaskData;
 
-  const availableStates = Object.values(TaskState).filter(s => s !== taskData.state);
+  const availableStates = TASK_STATE_VALUES.filter((state) => state !== taskData.state);
 
   return (
     <div className="bg-slate-700/70 p-3 rounded-lg border border-slate-600/80 shadow-md">
@@ -40,9 +40,9 @@ interface KanbanColumnProps {
 
 const KanbanColumn: React.FC<KanbanColumnProps> = ({ title, tasks, onUpdateTaskState }) => {
   const columnColors = {
-    [TaskState.Todo]: 'border-t-blue-400',
-    [TaskState.InProgress]: 'border-t-yellow-400',
-    [TaskState.Done]: 'border-t-green-400',
+    [TASK_STATE.Todo]: 'border-t-blue-400',
+    [TASK_STATE.InProgress]: 'border-t-yellow-400',
+    [TASK_STATE.Done]: 'border-t-green-400',
   };
 
   return (
@@ -74,7 +74,7 @@ const KanbanBoard: React.FC<KanbanBoardProps> = ({ artifacts, onUpdateArtifactDa
     }
   };
 
-  const columns = Object.values(TaskState).map(state => ({
+  const columns = TASK_STATE_VALUES.map((state) => ({
     title: state,
     tasks: tasks.filter(task => (task.data as TaskData).state === state),
   }));

--- a/code/components/ProjectInsights.tsx
+++ b/code/components/ProjectInsights.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Artifact, ArtifactType, ConlangLexeme, TaskData, TaskState } from '../types';
+import { Artifact, ArtifactType, ConlangLexeme, TaskData, TASK_STATE, type TaskState } from '../types';
 import { CubeIcon, ShareIcon, CheckCircleIcon, SparklesIcon } from './Icons';
 import { formatStatusLabel } from '../utils/status';
 
@@ -24,7 +24,7 @@ const ProjectInsights: React.FC<ProjectInsightsProps> = ({ artifacts }) => {
       },
       {} as Record<TaskState, number>
     );
-    const tasksComplete = taskStates[TaskState.Done] ?? 0;
+    const tasksComplete = taskStates[TASK_STATE.Done] ?? 0;
     const taskCompletionRate = tasks.length === 0 ? 0 : Math.round((tasksComplete / tasks.length) * 100);
 
     const conlangLexemeCount = artifacts
@@ -59,9 +59,9 @@ const ProjectInsights: React.FC<ProjectInsightsProps> = ({ artifacts }) => {
     };
   }, [artifacts]);
 
-  const doneCount = insights.taskStates[TaskState.Done] ?? 0;
-  const inProgressCount = insights.taskStates[TaskState.InProgress] ?? 0;
-  const todoCount = insights.taskStates[TaskState.Todo] ?? 0;
+  const doneCount = insights.taskStates[TASK_STATE.Done] ?? 0;
+  const inProgressCount = insights.taskStates[TASK_STATE.InProgress] ?? 0;
+  const todoCount = insights.taskStates[TASK_STATE.Todo] ?? 0;
 
   if (insights.totalArtifacts === 0) {
     return (

--- a/code/components/ReleaseNotesGenerator.tsx
+++ b/code/components/ReleaseNotesGenerator.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { Artifact, ArtifactType, ConlangLexeme, TaskData, TaskState } from '../types';
+import { Artifact, ArtifactType, ConlangLexeme, TaskData, TASK_STATE } from '../types';
 import { generateReleaseNotes } from '../services/geminiService';
 import { MegaphoneIcon, SparklesIcon, Spinner } from './Icons';
 
@@ -46,7 +46,7 @@ const ReleaseNotesGenerator: React.FC<ReleaseNotesGeneratorProps> = ({
       .filter((artifact) => artifact.type === ArtifactType.Task)
       .filter((artifact) => {
         const data = artifact.data as TaskData | undefined;
-        return data?.state === TaskState.Done;
+        return data?.state === TASK_STATE.Done;
       });
     if (completedTasks.length > 0) {
       lines.push(`Completed quests: ${formatListPreview(completedTasks.map((task) => task.title))}.`);

--- a/code/components/TaskEditor.tsx
+++ b/code/components/TaskEditor.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Artifact, TaskData, TaskState } from '../types';
+import { Artifact, TaskData, TASK_STATE, TASK_STATE_VALUES, type TaskState } from '../types';
 import { CalendarIcon, CheckCircleIcon, UserCircleIcon } from './Icons';
 
 interface TaskEditorProps {
@@ -8,14 +8,14 @@ interface TaskEditorProps {
 }
 
 const TaskEditor: React.FC<TaskEditorProps> = ({ artifact, onUpdateArtifactData }) => {
-  const initialData = (artifact.data as TaskData) ?? { state: TaskState.Todo };
-  const [taskState, setTaskState] = useState<TaskState>(initialData.state ?? TaskState.Todo);
+  const initialData = (artifact.data as TaskData) ?? { state: TASK_STATE.Todo };
+  const [taskState, setTaskState] = useState<TaskState>(initialData.state ?? TASK_STATE.Todo);
   const [assignee, setAssignee] = useState<string>(initialData.assignee ?? '');
   const [due, setDue] = useState<string>(initialData.due ?? '');
 
   useEffect(() => {
-    const currentData = (artifact.data as TaskData) ?? { state: TaskState.Todo };
-    setTaskState(currentData.state ?? TaskState.Todo);
+    const currentData = (artifact.data as TaskData) ?? { state: TASK_STATE.Todo };
+    setTaskState(currentData.state ?? TASK_STATE.Todo);
     setAssignee(currentData.assignee ?? '');
     setDue(currentData.due ?? '');
   }, [artifact.id, artifact.data]);
@@ -27,7 +27,7 @@ const TaskEditor: React.FC<TaskEditorProps> = ({ artifact, onUpdateArtifactData 
       due,
       ...updates,
     };
-    setTaskState(next.state ?? TaskState.Todo);
+    setTaskState(next.state ?? TASK_STATE.Todo);
     setAssignee(next.assignee ?? '');
     setDue(next.due ?? '');
     onUpdateArtifactData(artifact.id, next);
@@ -93,7 +93,7 @@ const TaskEditor: React.FC<TaskEditorProps> = ({ artifact, onUpdateArtifactData 
       <div className="space-y-3">
         <span className="text-xs font-semibold text-slate-400 uppercase tracking-wide">Status</span>
         <div className="flex flex-wrap gap-2">
-          {Object.values(TaskState).map((stateOption) => {
+          {TASK_STATE_VALUES.map((stateOption) => {
             const isActive = stateOption === taskState;
             return (
               <button

--- a/code/components/__tests__/QuestlineBoard.test.tsx
+++ b/code/components/__tests__/QuestlineBoard.test.tsx
@@ -3,7 +3,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import QuestlineBoard from '../QuestlineBoard';
-import { ArtifactType, Questline, TaskState, UserProfile } from '../../types';
+import { ArtifactType, Questline, TASK_STATE, type TaskState, UserProfile } from '../../types';
 
 const baseQuestline: Questline = {
   id: 'questline-test',
@@ -19,7 +19,7 @@ const baseQuestline: Questline = {
       isCompleted: (artifacts) =>
         artifacts.some(
           (artifact) =>
-            artifact.type === ArtifactType.Task && (artifact.data as { state: TaskState }).state === TaskState.Done,
+            artifact.type === ArtifactType.Task && (artifact.data as { state: TaskState }).state === TASK_STATE.Done,
         ),
     },
   ],
@@ -48,7 +48,7 @@ const completedArtifact = {
   status: 'done',
   tags: [],
   relations: [],
-  data: { state: TaskState.Done },
+  data: { state: TASK_STATE.Done },
 };
 
 describe('QuestlineBoard', () => {

--- a/code/components/__tests__/Quests.test.tsx
+++ b/code/components/__tests__/Quests.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 import React from 'react';
 import Quests from '../Quests';
-import { Artifact, ArtifactType, Project, ProjectStatus, Quest, TaskData, TaskState } from '../../types';
+import { Artifact, ArtifactType, Project, ProjectStatus, Quest, TaskData, TASK_STATE } from '../../types';
 
 describe('Quests component', () => {
   const projects: Project[] = [
@@ -19,7 +19,7 @@ describe('Quests component', () => {
       status: 'in-progress',
       tags: [],
       relations: [],
-      data: { state: TaskState.InProgress } satisfies TaskData,
+      data: { state: TASK_STATE.InProgress } satisfies TaskData,
     },
   ];
 
@@ -32,7 +32,7 @@ describe('Quests component', () => {
       isCompleted: (artifacts: Artifact[]) =>
         artifacts.some(
           artifact =>
-            artifact.type === ArtifactType.Task && (artifact.data as TaskData).state === TaskState.Done,
+            artifact.type === ArtifactType.Task && (artifact.data as TaskData).state === TASK_STATE.Done,
         ),
     },
     {
@@ -48,7 +48,7 @@ describe('Quests component', () => {
     const completedTask: Artifact = {
       ...baseArtifacts[0],
       id: 'art-2',
-      data: { state: TaskState.Done },
+      data: { state: TASK_STATE.Done },
     };
 
     render(<Quests quests={quests} artifacts={[...baseArtifacts, completedTask]} projects={projects} />);

--- a/code/components/__tests__/ReleaseNotesGenerator.test.tsx
+++ b/code/components/__tests__/ReleaseNotesGenerator.test.tsx
@@ -3,7 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import ReleaseNotesGenerator from '../ReleaseNotesGenerator';
-import { Artifact, ArtifactType, TaskState } from '../../types';
+import { Artifact, ArtifactType, TASK_STATE } from '../../types';
 import { generateReleaseNotes } from '../../services/geminiService';
 
 vi.mock('../../services/geminiService', () => ({
@@ -23,7 +23,7 @@ const baseArtifacts: Artifact[] = [
     status: 'done',
     tags: ['story'],
     relations: [],
-    data: { state: TaskState.Done },
+    data: { state: TASK_STATE.Done },
   },
   {
     id: 'story-1',

--- a/code/seedData.ts
+++ b/code/seedData.ts
@@ -1,4 +1,4 @@
-import { Artifact, ArtifactType, ConlangLexeme, LocationData, Project, ProjectStatus, TaskData, TaskState, CharacterData, WikiData, TimelineData } from './types';
+import { Artifact, ArtifactType, ConlangLexeme, LocationData, Project, ProjectStatus, TaskData, TASK_STATE, CharacterData, WikiData, TimelineData } from './types';
 
 export interface SeedWorkspace {
   projects: Project[];
@@ -76,7 +76,7 @@ export const createSeedWorkspace = (ownerId: string): SeedWorkspace => {
       status: 'in-progress',
       tags: ['design'],
       relations: [],
-      data: { state: TaskState.InProgress } as TaskData,
+      data: { state: TASK_STATE.InProgress } as TaskData,
     },
     {
       id: 'art-5',
@@ -88,7 +88,7 @@ export const createSeedWorkspace = (ownerId: string): SeedWorkspace => {
       status: 'todo',
       tags: ['writing'],
       relations: [],
-      data: { state: TaskState.Todo } as TaskData,
+      data: { state: TASK_STATE.Todo } as TaskData,
     },
     {
       id: 'art-6',

--- a/code/types.ts
+++ b/code/types.ts
@@ -50,11 +50,15 @@ export const NARRATIVE_ARTIFACT_TYPES: readonly ArtifactType[] = [
 export const isNarrativeArtifactType = (type: ArtifactType): boolean =>
   NARRATIVE_ARTIFACT_TYPES.includes(type);
 
-export enum TaskState {
-    Todo = 'Todo',
-    InProgress = 'In Progress',
-    Done = 'Done',
-}
+export const TASK_STATE = {
+    Todo: 'Todo',
+    InProgress: 'In Progress',
+    Done: 'Done',
+} as const;
+
+export type TaskState = typeof TASK_STATE[keyof typeof TASK_STATE];
+
+export const TASK_STATE_VALUES = Object.values(TASK_STATE) as TaskState[];
 
 export interface Relation {
     toId: string;

--- a/code/utils/__tests__/milestoneProgress.test.ts
+++ b/code/utils/__tests__/milestoneProgress.test.ts
@@ -11,7 +11,7 @@ import {
   Project,
   ProjectStatus,
   TaskData,
-  TaskState,
+  TASK_STATE,
   UserProfile,
 } from '../../types';
 
@@ -60,7 +60,7 @@ describe('evaluateMilestoneProgress', () => {
       status: 'done',
       tags: ['planning'],
       relations: [{ toId: 'art-story', kind: 'SUPPORTS' }],
-      data: { state: TaskState.Done } as TaskData,
+      data: { state: TASK_STATE.Done } as TaskData,
     },
     {
       id: 'art-conlang',

--- a/code/utils/export.ts
+++ b/code/utils/export.ts
@@ -8,7 +8,7 @@ import {
     LocationData,
     ConlangLexeme,
     TaskData,
-    TaskState,
+    TASK_STATE,
     WikiData,
     RepositoryData,
     IssueData,
@@ -330,7 +330,7 @@ const generateArtifactContent = (artifact: Artifact, allArtifacts: Artifact[]): 
         const task = artifact.data as TaskData;
         content += "<h2 class='text-2xl font-bold text-white mt-8 mb-4'>Task Details</h2>";
         content += "<div class='bg-slate-800 p-5 rounded-lg border border-slate-700 space-y-2 text-slate-300'>";
-        content += `<p><span class='text-slate-400'>State:</span> ${task?.state ?? TaskState.Todo}</p>`;
+        content += `<p><span class='text-slate-400'>State:</span> ${task?.state ?? TASK_STATE.Todo}</p>`;
         if (task?.assignee) {
             content += `<p><span class='text-slate-400'>Assignee:</span> ${task.assignee}</p>`;
         }

--- a/code/utils/import.ts
+++ b/code/utils/import.ts
@@ -6,7 +6,7 @@ import {
     ConlangLexeme,
     Scene,
     TaskData,
-    TaskState,
+    TASK_STATE,
     CharacterData,
     WikiData,
     LocationData,
@@ -27,7 +27,7 @@ const getDefaultDataForType = (type: ArtifactType): Artifact['data'] => {
         case ArtifactType.Conlang:
             return [];
         case ArtifactType.Task:
-            return { state: TaskState.Todo } as TaskData;
+            return { state: TASK_STATE.Todo } as TaskData;
         case ArtifactType.Character:
             return { bio: '', traits: [] } as CharacterData;
         case ArtifactType.Wiki:

--- a/code/utils/milestoneProgress.ts
+++ b/code/utils/milestoneProgress.ts
@@ -6,7 +6,7 @@ import {
   MilestoneObjective,
   Project,
   TaskData,
-  TaskState,
+  TASK_STATE,
   UserProfile,
   isNarrativeArtifactType,
 } from '../types';
@@ -121,7 +121,7 @@ const computeObjectiveStatus = (metric: MilestoneMetric | undefined, context: Ev
     case 'progression-loops': {
       const doneTasks = artifacts.filter((artifact) => artifact.type === ArtifactType.Task).filter((artifact) => {
         const data = artifact.data as TaskData | undefined;
-        return data?.state === TaskState.Done;
+        return data?.state === TASK_STATE.Done;
       }).length;
       const achievementsUnlocked = profile?.achievementsUnlocked?.length ?? 0;
       const xp = profile?.xp ?? 0;


### PR DESCRIPTION
## Summary
- replace the TaskState enum with a constant map and exported value list so bundling no longer references the value before initialization
- update components, utilities, and tests to consume the new TASK_STATE helpers

## Testing
- npm run lint --prefix code
- npm run test --prefix code

------
https://chatgpt.com/codex/tasks/task_e_6905a998ee4083288f87fecbee7008e4