### PR TITLE
Ensure Creative Atlas heading is visible during loading

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -25,7 +25,7 @@ import {
     WikiData,
     isNarrativeArtifactType,
 } from './types';
-import { PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon, SparklesIcon, GitHubIcon } from './components/Icons';
+import { PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon, SparklesIcon, GitHubIcon, CubeIcon } from './components/Icons';
 import Header from './components/Header';
 import Modal from './components/Modal';
 import CreateArtifactForm from './components/CreateArtifactForm';
@@ -390,6 +390,32 @@ const DAILY_QUEST_POOL: Quest[] = [
     xp: 13,
   },
 ];
+
+const DashboardShellPlaceholder: React.FC<{ loading: boolean }> = ({ loading }) => (
+  <div className="min-h-screen flex flex-col bg-slate-950">
+    <header className="bg-slate-900/80 backdrop-blur-sm border-b border-slate-800/70 px-4 sm:px-8 py-3">
+      <div className="flex items-center gap-3">
+        <CubeIcon className="w-7 h-7 text-cyan-400" />
+        <h1 className="text-xl font-bold text-slate-100">Creative Atlas</h1>
+      </div>
+    </header>
+    <main className="flex flex-1 items-center justify-center p-8">
+      <div className="text-center space-y-4" aria-live="polite">
+        <div className="flex items-center justify-center">
+          <div
+            aria-hidden="true"
+            className="h-12 w-12 animate-spin rounded-full border-2 border-cyan-400/60 border-t-transparent"
+          ></div>
+        </div>
+        <p className="text-sm text-slate-300">
+          {loading
+            ? 'Preparing your Creative Atlas workspace…'
+            : 'Your workspace is almost ready. If this message persists, please refresh the page.'}
+        </p>
+      </div>
+    </main>
+  </div>
+);
 
 const getCurrentDateKey = () => new Date().toISOString().slice(0, 10);
 
@@ -990,6 +1016,7 @@ export default function App() {
     projects,
     artifacts,
     profile,
+    loading,
     error,
     clearError,
     addXp,
@@ -1029,6 +1056,11 @@ export default function App() {
   const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const dataApiEnabled = isDataApiConfigured && !isGuestMode;
+  const selectedProject = useMemo(() => projects.find((project) => project.id === selectedProjectId), [projects, selectedProjectId]);
+  const projectArtifacts = useMemo(
+    () => artifacts.filter((artifact) => artifact.projectId === selectedProjectId),
+    [artifacts, selectedProjectId],
+  );
   const triggerDownload = useCallback((blob: Blob, filename: string) => {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -1577,7 +1609,6 @@ export default function App() {
     }
   };
 
-  const selectedProject = useMemo(() => projects.find(p => p.id === selectedProjectId), [projects, selectedProjectId]);
   const visibleProjects = useMemo(() => {
     const normalizedQuery = projectSearchTerm.trim().toLowerCase();
 
@@ -1596,7 +1627,6 @@ export default function App() {
       return true;
     });
   }, [projects, projectStatusFilter, projectSearchTerm]);
-  const projectArtifacts = useMemo(() => artifacts.filter(a => a.projectId === selectedProjectId), [artifacts, selectedProjectId]);
   const quickFacts = useMemo(() => {
     if (!selectedProjectId) {
       return [];
@@ -1851,7 +1881,7 @@ export default function App() {
   }, [markSelectedProjectActivity]);
 
   if (!profile) {
-    return null;
+    return <DashboardShellPlaceholder loading={loading} />;
   }
 
   const xpProgress = profile.xp % 100;

--- a/code/components/AuthGate.tsx
+++ b/code/components/AuthGate.tsx
@@ -170,10 +170,14 @@ const AuthGate: React.FC<{ children: React.ReactNode }> = ({ children }) => {
 
   if (authLoading || (!isGuestMode && user && dataLoading) || (isGuestMode && dataLoading)) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-slate-950 text-slate-300">
-        <div className="animate-pulse text-center">
-          <CubeIcon className="w-10 h-10 mx-auto text-cyan-400 mb-3" />
+      <div className="min-h-screen flex flex-col items-center justify-center bg-slate-950 px-6 text-slate-300">
+        <div className="flex items-center gap-3 mb-6">
+          <CubeIcon className="w-10 h-10 text-cyan-400" />
+          <h1 className="text-2xl font-bold text-white">Creative Atlas</h1>
+        </div>
+        <div className="animate-pulse text-center space-y-2" role="status" aria-live="polite">
           <p className="text-sm">Loading your creative workspace…</p>
+          <p className="text-xs text-slate-500">This should only take a moment.</p>
         </div>
       </div>
     );


### PR DESCRIPTION
## Summary
- show a Creative Atlas heading while the dashboard seed data loads so the smoke test can assert it immediately
- reuse that heading in the auth loading screen and announce status text for better accessibility
- initialize project-derived memoized data before callbacks that depend on it to prevent runtime reference errors

## Testing
- npm run test:e2e

------
https://chatgpt.com/codex/tasks/task_e_6905aca05ee483288ac636224b690237