### PR TITLE
Fix GitHub OAuth redirect to use configured API base

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -55,7 +55,7 @@ import StreakTracker from './components/StreakTracker';
 import QuestlineBoard from './components/QuestlineBoard';
 import { useUserData } from './contexts/UserDataContext';
 import { useAuth } from './contexts/AuthContext';
-import { downloadProjectExport, importArtifactsViaApi, isDataApiConfigured } from './services/dataApi';
+import { dataApiBaseUrl, downloadProjectExport, importArtifactsViaApi, isDataApiConfigured } from './services/dataApi';
 import UserProfileCard from './components/UserProfileCard';
 import GitHubImportPanel from './components/GitHubImportPanel';
 import SecondaryInsightsPanel from './components/SecondaryInsightsPanel';
@@ -1837,7 +1837,12 @@ export default function App() {
   };
 
   const handlePublishToGithub = () => {
-    window.location.href = `/api/github/oauth/start`;
+    if (!isDataApiConfigured || !dataApiBaseUrl) {
+      alert('Publishing to GitHub is unavailable because the data API is not configured.');
+      return;
+    }
+
+    window.location.href = `${dataApiBaseUrl}/api/github/oauth/start`;
   }
 
   const handlePublishToGithubRepo = async (repoName: string, publishDir: string) => {

--- a/code/services/dataApi.ts
+++ b/code/services/dataApi.ts
@@ -2,6 +2,8 @@ import type { Artifact, ConlangLexeme, Project, UserProfile } from '../types';
 
 const API_BASE_URL = import.meta.env.VITE_DATA_API_BASE_URL?.replace(/\/$/, '') ?? '';
 
+export const dataApiBaseUrl = API_BASE_URL;
+
 export const isDataApiConfigured = API_BASE_URL.length > 0;
 
 const withAuth = async (token: string | null, init: RequestInit = {}): Promise<RequestInit> => {


### PR DESCRIPTION
## Summary
- export the configured data API base URL from the frontend data service
- update the GitHub publish handler to redirect through the API base and guard when the service is unavailable

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_6905b00937448328bf0d0be12db58b96