### PR TITLE
Add chapter bible and lore export pipelines

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -25,7 +25,7 @@ import {
     WikiData,
     isNarrativeArtifactType,
 } from './types';
-import { PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon, SparklesIcon, GitHubIcon, CubeIcon } from './components/Icons';
+import { PlusIcon, TableCellsIcon, ShareIcon, ArrowDownTrayIcon, ViewColumnsIcon, ArrowUpTrayIcon, BuildingStorefrontIcon, FolderPlusIcon, SparklesIcon, GitHubIcon, CubeIcon, BookOpenIcon } from './components/Icons';
 import Header from './components/Header';
 import Modal from './components/Modal';
 import CreateArtifactForm from './components/CreateArtifactForm';
@@ -44,7 +44,7 @@ import WikiEditor from './components/WikiEditor';
 import LocationEditor from './components/LocationEditor';
 import TaskEditor from './components/TaskEditor';
 import TimelineEditor from './components/TimelineEditor';
-import { exportProjectAsStaticSite } from './utils/export';
+import { exportProjectAsStaticSite, exportChapterBibleMarkdown, exportChapterBiblePdf, exportLoreJson } from './utils/export';
 import ProjectOverview from './components/ProjectOverview';
 import ProjectInsights from './components/ProjectInsights';
 import { formatStatusLabel } from './utils/status';
@@ -2100,6 +2100,51 @@ export default function App() {
     [selectedProject, dataApiEnabled, getIdToken, triggerDownload, markSelectedProjectActivity],
   );
 
+  const handleChapterBibleExport = useCallback(
+    async (format: 'markdown' | 'pdf') => {
+      if (!selectedProject) {
+        return;
+      }
+
+      if (projectArtifacts.length === 0) {
+        alert('Capture some lore before exporting a chapter bible.');
+        return;
+      }
+
+      try {
+        if (format === 'markdown') {
+          exportChapterBibleMarkdown(selectedProject, projectArtifacts);
+        } else {
+          await exportChapterBiblePdf(selectedProject, projectArtifacts);
+        }
+        markSelectedProjectActivity({ exportedData: true });
+      } catch (error) {
+        console.error('Chapter bible export failed', error);
+        alert('Unable to export the chapter bible right now. Please try again.');
+      }
+    },
+    [selectedProject, projectArtifacts, markSelectedProjectActivity],
+  );
+
+  const handleLoreJsonExport = useCallback(() => {
+    if (!selectedProject) {
+      return;
+    }
+
+    if (projectArtifacts.length === 0) {
+      alert('Capture some lore before exporting a lore bundle.');
+      return;
+    }
+
+    try {
+      exportLoreJson(selectedProject, projectArtifacts);
+      markSelectedProjectActivity({ exportedData: true });
+    } catch (error) {
+      console.error('Lore JSON export failed', error);
+      alert('Unable to export lore JSON right now. Please try again.');
+    }
+  }, [selectedProject, projectArtifacts, markSelectedProjectActivity]);
+
   const handleLoadMoreProjects = useCallback(async () => {
     if (!canLoadMoreProjects) {
       return;
@@ -2342,6 +2387,15 @@ export default function App() {
                         </button>
                         <button onClick={() => { void handleExportArtifacts('tsv'); }} title="Export to TSV" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
                             <span className="flex items-center justify-center w-5 h-5 text-xs font-bold">TSV</span>
+                        </button>
+                        <button onClick={() => { void handleChapterBibleExport('markdown'); }} title="Export chapter bible (Markdown)" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
+                            <BookOpenIcon className="w-5 h-5" />
+                        </button>
+                        <button onClick={() => { void handleChapterBibleExport('pdf'); }} title="Export chapter bible (PDF)" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
+                            <span className="flex items-center justify-center w-5 h-5 text-xs font-bold">PDF</span>
+                        </button>
+                        <button onClick={handleLoreJsonExport} title="Export lore JSON for game engines" className="p-2 text-sm font-semibold text-slate-300 bg-slate-700/50 hover:bg-slate-700 rounded-md transition-colors">
+                            <CubeIcon className="w-5 h-5" />
                         </button>
                         <ViewSwitcher />
                         <button

--- a/code/package-lock.json
+++ b/code/package-lock.json
@@ -13,6 +13,7 @@
         "@floating-ui/react-dom": "^2.1.6",
         "@google/genai": "^1.20.0",
         "firebase": "^12.4.0",
+        "jspdf": "^3.0.3",
         "jszip": "^3.10.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -326,7 +327,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -3021,6 +3021,19 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/pako": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/react": {
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.2.tgz",
@@ -3040,6 +3053,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.46.2",
@@ -3780,6 +3800,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -3996,6 +4026,26 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/canvg": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.11.tgz",
+      "integrity": "sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/chai": {
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
@@ -4162,6 +4212,18 @@
         "node": ">=18"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.46.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.46.0.tgz",
+      "integrity": "sha512-vDMm9B0xnqqZ8uSBpZ8sNtRtOdmfShrvT6h2TuQGLs0Is+cR0DYbj/KWP6ALVNbWPpqA/qPLoOuppJN07humpA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4181,6 +4243,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/css.escape": {
@@ -4551,6 +4623,16 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.0.tgz",
+      "integrity": "sha512-r+f6MYR1gGN1eJv0TVQbhA7if/U7P87cdPl3HN5rikqaBSBxLiCb/b9O+2eG0cxz0ghyU+mU1QkbsOwERMYlWQ==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -5326,6 +5408,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-png": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/fast-png/-/fast-png-6.4.0.tgz",
+      "integrity": "sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/pako": "^2.0.3",
+        "iobuffer": "^5.3.2",
+        "pako": "^2.1.0"
+      }
+    },
+    "node_modules/fast-png/node_modules/pako": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -5388,6 +5487,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5966,6 +6071,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
@@ -6091,6 +6210,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/iobuffer": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/iobuffer/-/iobuffer-5.4.0.tgz",
+      "integrity": "sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==",
+      "license": "MIT"
     },
     "node_modules/is-array-buffer": {
       "version": "3.0.5",
@@ -6685,6 +6810,23 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.3.tgz",
+      "integrity": "sha512-eURjAyz5iX1H8BOYAfzvdPfIKK53V7mCpBTe7Kb16PaM8JSXEcUQNBQaiWMI8wY5RvNOPj4GccMjTlfwRBd+oQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.9",
+        "fast-png": "^6.2.0",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.11",
+        "core-js": "^3.6.0",
+        "dompurify": "^3.2.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/jsx-ast-utils": {
@@ -7407,6 +7549,13 @@
         "node": ">= 14.16"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -7814,6 +7963,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
@@ -8003,6 +8162,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -8080,6 +8246,16 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
       }
     },
     "node_modules/rollup": {
@@ -8477,6 +8653,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -8770,6 +8956,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -8840,6 +9036,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/thenify": {
@@ -9196,6 +9402,16 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/vite": {
       "version": "7.1.12",

--- a/code/package.json
+++ b/code/package.json
@@ -18,6 +18,7 @@
     "@floating-ui/react-dom": "^2.1.6",
     "@google/genai": "^1.20.0",
     "firebase": "^12.4.0",
+    "jspdf": "^3.0.3",
     "jszip": "^3.10.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/code/utils/__tests__/exportChapterBible.test.ts
+++ b/code/utils/__tests__/exportChapterBible.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from 'vitest';
+import {
+  Artifact,
+  ArtifactType,
+  CharacterData,
+  ConlangLexeme,
+  LocationData,
+  Project,
+  ProjectStatus,
+  Scene,
+  TimelineData,
+  WikiData,
+} from '../../types';
+import { buildChapterBibleContent, createLoreJsonPayload } from '../export';
+
+describe('chapter bible exports', () => {
+  const project: Project = {
+    id: 'proj-test',
+    ownerId: 'user-1',
+    title: 'Skybound Atlas',
+    summary: 'A compendium of aerial adventures.',
+    status: ProjectStatus.Active,
+    tags: ['dustland', 'campaign'],
+  };
+
+  const storyScenes: Scene[] = [
+    { id: 'scene-1', title: 'Opening Gambit', summary: 'Dawn over the floating docks.' },
+    { id: 'scene-2', title: 'Stormcall', summary: 'The crew invites the tempest spirits.' },
+  ];
+
+  const lexemes: ConlangLexeme[] = [
+    { id: 'lex-1', lemma: 'aerith', pos: 'noun', gloss: 'sky current', etymology: 'Old Darv aer + ith' },
+  ];
+
+  const locationData: LocationData = {
+    description: 'A citadel suspended above the desert.',
+    features: [{ id: 'feat-1', name: 'Sky Harbor', description: 'Launch point for wind skiffs.' }],
+  };
+
+  const characterData: CharacterData = {
+    bio: 'Navigator of the airship Aetherwing.',
+    traits: [{ id: 'trait-1', key: 'Role', value: 'Navigator' }],
+  };
+
+  const timelineData: TimelineData = {
+    events: [
+      { id: 'ev-1', date: 'Year 0', title: 'Ascension', description: 'Skybound Atlas takes flight.' },
+    ],
+  };
+
+  const wikiData: WikiData = {
+    content: '## Aether Guild\n\nCustodians of sky routes.',
+  };
+
+  const artifacts: Artifact[] = [
+    {
+      id: 'story-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Novel,
+      title: 'Echo Drift',
+      summary: 'A saga of skyfarers.',
+      status: 'draft',
+      tags: ['story'],
+      relations: [{ toId: 'module-1', kind: 'INSPIRES' }],
+      data: storyScenes,
+    },
+    {
+      id: 'chapter-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Chapter,
+      title: 'Chapter 1: Windrise',
+      summary: 'Introduces the crew and their mission.',
+      status: 'draft',
+      tags: ['chapter'],
+      relations: [{ toId: 'location-1', kind: 'SET_IN' }],
+      data: [],
+    },
+    {
+      id: 'character-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Character,
+      title: 'Captain Lysa',
+      summary: 'Veteran pilot of the fleet.',
+      status: 'draft',
+      tags: ['protagonist'],
+      relations: [{ toId: 'location-1', kind: 'STATIONED_AT' }],
+      data: characterData,
+    },
+    {
+      id: 'location-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Location,
+      title: 'Aether Spire',
+      summary: 'Primary base suspended above the dust seas.',
+      status: 'draft',
+      tags: ['hub'],
+      relations: [],
+      data: locationData,
+    },
+    {
+      id: 'conlang-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Conlang,
+      title: 'Aetherine',
+      summary: 'Language of the sky guild.',
+      status: 'draft',
+      tags: ['language'],
+      relations: [],
+      data: lexemes,
+    },
+    {
+      id: 'timeline-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Timeline,
+      title: 'Skybound Timeline',
+      summary: 'Major events of the fleet.',
+      status: 'draft',
+      tags: ['history'],
+      relations: [],
+      data: timelineData,
+    },
+    {
+      id: 'term-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Terminology,
+      title: 'Windcallers',
+      summary: 'Mages who broker weather pacts.',
+      status: 'draft',
+      tags: ['magic'],
+      relations: [{ toId: 'character-1', kind: 'DEFINED_FOR' }],
+      data: {},
+    },
+    {
+      id: 'wiki-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.Wiki,
+      title: 'Guild Primer',
+      summary: 'Overview of the guild hierarchy.',
+      status: 'draft',
+      tags: ['reference'],
+      relations: [],
+      data: wikiData,
+    },
+    {
+      id: 'module-1',
+      ownerId: 'user-1',
+      projectId: project.id,
+      type: ArtifactType.GameModule,
+      title: 'Echo Drift Module',
+      summary: 'Dustland ACK hook for the crew.',
+      status: 'draft',
+      tags: ['module'],
+      relations: [
+        { toId: 'character-1', kind: 'FEATURES' },
+        { toId: 'location-1', kind: 'LOCATED_AT' },
+      ],
+      data: [],
+    },
+  ];
+
+  it('builds a structured chapter bible from project artifacts', () => {
+    const content = buildChapterBibleContent(project, artifacts);
+
+    expect(content.project.title).toBe('Skybound Atlas');
+    expect(content.storylines).toHaveLength(1);
+    expect(content.storylines[0].scenes.map((scene) => scene.title)).toEqual([
+      'Opening Gambit',
+      'Stormcall',
+    ]);
+    expect(content.storylines[0].relations[0].targetTitle).toBe('Echo Drift Module');
+
+    expect(content.chapters[0].relations[0].targetTitle).toBe('Aether Spire');
+    expect(content.characters[0].traits[0]).toMatchObject({ key: 'Role', value: 'Navigator' });
+    expect(content.characters[0].relations[0].targetTitle).toBe('Aether Spire');
+
+    expect(content.lexicon[0]).toMatchObject({ language: 'Aetherine', lemma: 'aerith' });
+    expect(content.timelineEntries[0].events[0].title).toBe('Ascension');
+    expect(content.gameModules[0].relations).toHaveLength(2);
+  });
+
+  it('produces lore JSON shaped for game integrations', () => {
+    const content = buildChapterBibleContent(project, artifacts);
+    const payload = createLoreJsonPayload(content);
+
+    expect(payload.metadata.projectTitle).toBe('Skybound Atlas');
+    expect(payload.narrative.storylines[0].scenes[1].order).toBe(2);
+    expect(payload.lore.characters[0].relations[0].targetTitle).toBe('Aether Spire');
+    expect(payload.ackModule.modules[0].relations.map((relation) => relation.targetType)).toContain(
+      ArtifactType.Location,
+    );
+  });
+});

--- a/code/utils/export.ts
+++ b/code/utils/export.ts
@@ -13,10 +13,114 @@ import {
     RepositoryData,
     IssueData,
     ReleaseData,
+    TimelineData,
     isNarrativeArtifactType,
 } from '../types';
 import JSZip from 'jszip';
 import { simpleMarkdownToHtml, escapeMarkdownCell } from './markdown';
+
+interface ResolvedRelation {
+    kind: string;
+    targetId: string;
+    targetTitle: string;
+    targetType: ArtifactType;
+}
+
+interface ChapterSummary {
+    id: string;
+    title: string;
+    summary: string;
+    status: string;
+    tags: string[];
+    relations: ResolvedRelation[];
+}
+
+interface StorylineSummary {
+    id: string;
+    title: string;
+    summary: string;
+    status: string;
+    type: ArtifactType;
+    tags: string[];
+    scenes: Scene[];
+    relations: ResolvedRelation[];
+}
+
+interface CharacterSummary {
+    id: string;
+    title: string;
+    summary: string;
+    status: string;
+    tags: string[];
+    bio: string;
+    traits: { id: string; key: string; value: string }[];
+    relations: ResolvedRelation[];
+}
+
+interface LocationSummary {
+    id: string;
+    title: string;
+    summary: string;
+    status: string;
+    tags: string[];
+    description: string;
+    features: { id: string; name: string; description: string }[];
+    relations: ResolvedRelation[];
+}
+
+interface TimelineSummary {
+    id: string;
+    title: string;
+    summary: string;
+    events: { id: string; date: string; title: string; description: string }[];
+}
+
+interface WikiSummary {
+    id: string;
+    title: string;
+    summary: string;
+    content: string;
+}
+
+interface TerminologySummary {
+    id: string;
+    title: string;
+    summary: string;
+    tags: string[];
+    relations: ResolvedRelation[];
+}
+
+interface GameModuleSummary {
+    id: string;
+    title: string;
+    summary: string;
+    status: string;
+    tags: string[];
+    relations: ResolvedRelation[];
+}
+
+interface LexemeSummary extends ConlangLexeme {
+    language: string;
+    artifactId: string;
+}
+
+interface ChapterBibleContent {
+    project: {
+        id: string;
+        title: string;
+        summary: string;
+        tags: string[];
+    };
+    chapters: ChapterSummary[];
+    storylines: StorylineSummary[];
+    characters: CharacterSummary[];
+    locations: LocationSummary[];
+    timelineEntries: TimelineSummary[];
+    terminology: TerminologySummary[];
+    lexicon: LexemeSummary[];
+    wikiPages: WikiSummary[];
+    gameModules: GameModuleSummary[];
+}
 
 function escapeCsvCell(cell: unknown): string {
     const cellStr = String(cell ?? '');
@@ -37,6 +141,869 @@ const serializeArtifactData = (artifact: Artifact): string => {
         console.warn(`Failed to serialize data for artifact ${artifact.id}`, error);
         return '';
     }
+};
+
+const sortByTitle = <T extends { title: string }>(items: T[]): T[] =>
+    [...items].sort((a, b) => a.title.localeCompare(b.title, undefined, { sensitivity: 'base' }));
+
+const resolveRelations = (
+    artifact: Artifact,
+    artifactMap: Map<string, Artifact>,
+): ResolvedRelation[] =>
+    artifact.relations
+        .map((relation) => {
+            const target = artifactMap.get(relation.toId);
+            if (!target) {
+                return null;
+            }
+            return {
+                kind: relation.kind,
+                targetId: relation.toId,
+                targetTitle: target.title,
+                targetType: target.type,
+            } satisfies ResolvedRelation;
+        })
+        .filter((relation): relation is ResolvedRelation => relation !== null);
+
+export const buildChapterBibleContent = (project: Project, artifacts: Artifact[]): ChapterBibleContent => {
+    const projectArtifacts = artifacts.filter((artifact) => artifact.projectId === project.id);
+    const artifactMap = new Map(projectArtifacts.map((artifact) => [artifact.id, artifact] as const));
+
+    const chapters: ChapterSummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => artifact.type === ArtifactType.Chapter)
+            .map((artifact) => ({
+                id: artifact.id,
+                title: artifact.title,
+                summary: artifact.summary,
+                status: artifact.status,
+                tags: [...artifact.tags],
+                relations: resolveRelations(artifact, artifactMap),
+            })),
+    );
+
+    const storylines: StorylineSummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => isNarrativeArtifactType(artifact.type) && artifact.type !== ArtifactType.Chapter)
+            .map((artifact) => {
+                const scenes = Array.isArray(artifact.data)
+                    ? (artifact.data as Scene[]).filter((scene): scene is Scene => Boolean(scene?.title))
+                    : [];
+                return {
+                    id: artifact.id,
+                    title: artifact.title,
+                    summary: artifact.summary,
+                    status: artifact.status,
+                    type: artifact.type,
+                    tags: [...artifact.tags],
+                    scenes,
+                    relations: resolveRelations(artifact, artifactMap),
+                } satisfies StorylineSummary;
+            }),
+    );
+
+    const characters: CharacterSummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => artifact.type === ArtifactType.Character)
+            .map((artifact) => {
+                const data = artifact.data as CharacterData | undefined;
+                return {
+                    id: artifact.id,
+                    title: artifact.title,
+                    summary: artifact.summary,
+                    status: artifact.status,
+                    tags: [...artifact.tags],
+                    bio: data?.bio ?? '',
+                    traits: Array.isArray(data?.traits) ? data.traits : [],
+                    relations: resolveRelations(artifact, artifactMap),
+                } satisfies CharacterSummary;
+            }),
+    );
+
+    const locations: LocationSummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => artifact.type === ArtifactType.Location)
+            .map((artifact) => {
+                const data = artifact.data as LocationData | undefined;
+                const features = Array.isArray(data?.features) ? data.features : [];
+                return {
+                    id: artifact.id,
+                    title: artifact.title,
+                    summary: artifact.summary,
+                    status: artifact.status,
+                    tags: [...artifact.tags],
+                    description: data?.description ?? '',
+                    features,
+                    relations: resolveRelations(artifact, artifactMap),
+                } satisfies LocationSummary;
+            }),
+    );
+
+    const timelineEntries: TimelineSummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => artifact.type === ArtifactType.Timeline)
+            .map((artifact) => {
+                const data = artifact.data as TimelineData | undefined;
+                const events = Array.isArray(data?.events) ? data.events : [];
+                return {
+                    id: artifact.id,
+                    title: artifact.title,
+                    summary: artifact.summary,
+                    events,
+                } satisfies TimelineSummary;
+            }),
+    );
+
+    const terminology: TerminologySummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => artifact.type === ArtifactType.Terminology)
+            .map((artifact) => ({
+                id: artifact.id,
+                title: artifact.title,
+                summary: artifact.summary,
+                tags: [...artifact.tags],
+                relations: resolveRelations(artifact, artifactMap),
+            })),
+    );
+
+    const wikiPages: WikiSummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => artifact.type === ArtifactType.Wiki)
+            .map((artifact) => {
+                const data = artifact.data as WikiData | undefined;
+                return {
+                    id: artifact.id,
+                    title: artifact.title,
+                    summary: artifact.summary,
+                    content: data?.content ?? '',
+                } satisfies WikiSummary;
+            }),
+    );
+
+    const gameModules: GameModuleSummary[] = sortByTitle(
+        projectArtifacts
+            .filter((artifact) => artifact.type === ArtifactType.GameModule)
+            .map((artifact) => ({
+                id: artifact.id,
+                title: artifact.title,
+                summary: artifact.summary,
+                status: artifact.status,
+                tags: [...artifact.tags],
+                relations: resolveRelations(artifact, artifactMap),
+            })),
+    );
+
+    const lexicon: LexemeSummary[] = projectArtifacts
+        .filter((artifact) => artifact.type === ArtifactType.Conlang)
+        .flatMap((artifact) => {
+            const lexemes = Array.isArray(artifact.data) ? (artifact.data as ConlangLexeme[]) : [];
+            return lexemes.map((lexeme) => ({
+                ...lexeme,
+                language: artifact.title,
+                artifactId: artifact.id,
+            } satisfies LexemeSummary));
+        })
+        .sort((a, b) => a.lemma.localeCompare(b.lemma, undefined, { sensitivity: 'base' }));
+
+    return {
+        project: {
+            id: project.id,
+            title: project.title,
+            summary: project.summary,
+            tags: [...project.tags],
+        },
+        chapters,
+        storylines,
+        characters,
+        locations,
+        timelineEntries,
+        terminology,
+        lexicon,
+        wikiPages,
+        gameModules,
+    } satisfies ChapterBibleContent;
+};
+
+const slugifyForFilename = (value: string): string =>
+    value
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_|_$/g, '') || 'export';
+
+const formatRelationForMarkdown = (relation: ResolvedRelation): string =>
+    `${relation.kind.replace(/_/g, ' ')} → ${relation.targetTitle} (${relation.targetType})`;
+
+const createChapterBibleMarkdown = (content: ChapterBibleContent): string => {
+    const lines: string[] = [];
+    const addBlankLine = () => {
+        if (lines.length === 0 || lines[lines.length - 1] !== '') {
+            lines.push('');
+        }
+    };
+
+    lines.push(`# ${content.project.title} — Chapter Bible`);
+    lines.push('');
+    lines.push(`**Summary:** ${content.project.summary || 'No summary recorded.'}`);
+    if (content.project.tags.length > 0) {
+        lines.push(`**Project Tags:** ${content.project.tags.map((tag) => `\`${tag}\``).join(', ')}`);
+    }
+    lines.push('');
+    lines.push(`_Generated on ${new Date().toISOString()}_`);
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+
+    if (content.storylines.length > 0) {
+        lines.push('## Storylines & Scenes');
+        lines.push('');
+        content.storylines.forEach((storyline) => {
+            lines.push(`### ${storyline.title} (${storyline.type})`);
+            if (storyline.summary) {
+                lines.push('');
+                lines.push(storyline.summary);
+            }
+            addBlankLine();
+            const metadata: string[] = [`- **Status:** ${storyline.status}`];
+            if (storyline.tags.length > 0) {
+                metadata.push(`- **Tags:** ${storyline.tags.map((tag) => `\`${tag}\``).join(', ')}`);
+            }
+            metadata.forEach((item) => lines.push(item));
+            addBlankLine();
+            if (storyline.scenes.length > 0) {
+                lines.push('#### Scenes');
+                lines.push('');
+                storyline.scenes.forEach((scene, index) => {
+                    const summary = scene.summary ? ` — ${scene.summary}` : '';
+                    lines.push(`${index + 1}. **${scene.title}**${summary}`);
+                });
+                addBlankLine();
+            }
+            if (storyline.relations.length > 0) {
+                lines.push('#### Relations');
+                lines.push('');
+                storyline.relations.forEach((relation) => {
+                    lines.push(`- ${formatRelationForMarkdown(relation)}`);
+                });
+                addBlankLine();
+            }
+        });
+    }
+
+    if (content.chapters.length > 0) {
+        lines.push('## Chapters');
+        lines.push('');
+        content.chapters.forEach((chapter) => {
+            lines.push(`### ${chapter.title}`);
+            if (chapter.summary) {
+                lines.push('');
+                lines.push(chapter.summary);
+            }
+            addBlankLine();
+            const metadata: string[] = [`- **Status:** ${chapter.status}`];
+            if (chapter.tags.length > 0) {
+                metadata.push(`- **Tags:** ${chapter.tags.map((tag) => `\`${tag}\``).join(', ')}`);
+            }
+            metadata.forEach((item) => lines.push(item));
+            addBlankLine();
+            if (chapter.relations.length > 0) {
+                lines.push('#### Relations');
+                lines.push('');
+                chapter.relations.forEach((relation) => {
+                    lines.push(`- ${formatRelationForMarkdown(relation)}`);
+                });
+                addBlankLine();
+            }
+        });
+    }
+
+    if (content.characters.length > 0) {
+        lines.push('## Characters');
+        lines.push('');
+        content.characters.forEach((character) => {
+            lines.push(`### ${character.title}`);
+            if (character.summary) {
+                lines.push('');
+                lines.push(character.summary);
+            }
+            addBlankLine();
+            const metadata: string[] = [`- **Status:** ${character.status}`];
+            if (character.tags.length > 0) {
+                metadata.push(`- **Tags:** ${character.tags.map((tag) => `\`${tag}\``).join(', ')}`);
+            }
+            metadata.forEach((item) => lines.push(item));
+            addBlankLine();
+            if (character.bio) {
+                lines.push('**Biography**');
+                lines.push('');
+                lines.push(character.bio);
+                addBlankLine();
+            }
+            if (character.traits.length > 0) {
+                lines.push('#### Traits');
+                lines.push('');
+                character.traits.forEach((trait) => {
+                    lines.push(`- **${trait.key}:** ${trait.value}`);
+                });
+                addBlankLine();
+            }
+            if (character.relations.length > 0) {
+                lines.push('#### Relations');
+                lines.push('');
+                character.relations.forEach((relation) => {
+                    lines.push(`- ${formatRelationForMarkdown(relation)}`);
+                });
+                addBlankLine();
+            }
+        });
+    }
+
+    if (content.locations.length > 0) {
+        lines.push('## Locations');
+        lines.push('');
+        content.locations.forEach((location) => {
+            lines.push(`### ${location.title}`);
+            if (location.summary) {
+                lines.push('');
+                lines.push(location.summary);
+            }
+            addBlankLine();
+            const metadata: string[] = [`- **Status:** ${location.status}`];
+            if (location.tags.length > 0) {
+                metadata.push(`- **Tags:** ${location.tags.map((tag) => `\`${tag}\``).join(', ')}`);
+            }
+            metadata.forEach((item) => lines.push(item));
+            addBlankLine();
+            if (location.description) {
+                lines.push('**Description**');
+                lines.push('');
+                lines.push(location.description);
+                addBlankLine();
+            }
+            if (location.features.length > 0) {
+                lines.push('#### Notable Features');
+                lines.push('');
+                location.features.forEach((feature) => {
+                    lines.push(`- **${feature.name}:** ${feature.description}`);
+                });
+                addBlankLine();
+            }
+            if (location.relations.length > 0) {
+                lines.push('#### Relations');
+                lines.push('');
+                location.relations.forEach((relation) => {
+                    lines.push(`- ${formatRelationForMarkdown(relation)}`);
+                });
+                addBlankLine();
+            }
+        });
+    }
+
+    if (content.timelineEntries.length > 0) {
+        lines.push('## Timelines');
+        lines.push('');
+        content.timelineEntries.forEach((timeline) => {
+            lines.push(`### ${timeline.title}`);
+            if (timeline.summary) {
+                lines.push('');
+                lines.push(timeline.summary);
+            }
+            addBlankLine();
+            if (timeline.events.length > 0) {
+                timeline.events.forEach((event) => {
+                    const detail = event.description ? ` — ${event.description}` : '';
+                    lines.push(`- ${event.date}: **${event.title}**${detail}`);
+                });
+                addBlankLine();
+            }
+        });
+    }
+
+    if (content.terminology.length > 0) {
+        lines.push('## Terminology & Glossary');
+        lines.push('');
+        content.terminology.forEach((entry) => {
+            lines.push(`- **${entry.title}:** ${entry.summary || 'No definition captured yet.'}`);
+            if (entry.tags.length > 0) {
+                lines.push(`  - Tags: ${entry.tags.map((tag) => `\`${tag}\``).join(', ')}`);
+            }
+            if (entry.relations.length > 0) {
+                entry.relations.forEach((relation) => {
+                    lines.push(`  - ${formatRelationForMarkdown(relation)}`);
+                });
+            }
+        });
+        addBlankLine();
+    }
+
+    if (content.lexicon.length > 0) {
+        lines.push('## Lexicon');
+        lines.push('');
+        lines.push('| Language | Lemma | Part of Speech | Gloss | Etymology |');
+        lines.push('| --- | --- | --- | --- | --- |');
+        content.lexicon.forEach((lexeme) => {
+            lines.push(
+                `| ${escapeMarkdownCell(lexeme.language)} | ${escapeMarkdownCell(lexeme.lemma)} | ${escapeMarkdownCell(
+                    lexeme.pos,
+                )} | ${escapeMarkdownCell(lexeme.gloss)} | ${escapeMarkdownCell(lexeme.etymology ?? '')} |`,
+            );
+        });
+        addBlankLine();
+    }
+
+    if (content.wikiPages.length > 0) {
+        lines.push('## Wiki Pages');
+        lines.push('');
+        content.wikiPages.forEach((wiki) => {
+            lines.push(`### ${wiki.title}`);
+            if (wiki.summary) {
+                lines.push('');
+                lines.push(wiki.summary);
+            }
+            if (wiki.content) {
+                lines.push('');
+                lines.push(wiki.content);
+            }
+            addBlankLine();
+        });
+    }
+
+    if (content.gameModules.length > 0) {
+        lines.push('## Game Modules');
+        lines.push('');
+        content.gameModules.forEach((module) => {
+            lines.push(`### ${module.title}`);
+            if (module.summary) {
+                lines.push('');
+                lines.push(module.summary);
+            }
+            addBlankLine();
+            const metadata: string[] = [`- **Status:** ${module.status}`];
+            if (module.tags.length > 0) {
+                metadata.push(`- **Tags:** ${module.tags.map((tag) => `\`${tag}\``).join(', ')}`);
+            }
+            metadata.forEach((item) => lines.push(item));
+            addBlankLine();
+            if (module.relations.length > 0) {
+                lines.push('#### Relations');
+                lines.push('');
+                module.relations.forEach((relation) => {
+                    lines.push(`- ${formatRelationForMarkdown(relation)}`);
+                });
+                addBlankLine();
+            }
+        });
+    }
+
+    return lines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd().concat('\n');
+};
+
+const triggerBlobDownload = (blob: Blob, filename: string) => {
+    const link = document.createElement('a');
+    const url = URL.createObjectURL(blob);
+    link.href = url;
+    link.setAttribute('download', filename);
+    link.style.visibility = 'hidden';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+};
+
+export const exportChapterBibleMarkdown = (project: Project, artifacts: Artifact[]) => {
+    const content = buildChapterBibleContent(project, artifacts);
+    const markdown = createChapterBibleMarkdown(content);
+    const filename = `${slugifyForFilename(project.title)}_chapter_bible.md`;
+    triggerBlobDownload(new Blob([markdown], { type: 'text/markdown;charset=utf-8;' }), filename);
+};
+
+export const exportChapterBiblePdf = async (project: Project, artifacts: Artifact[]) => {
+    const content = buildChapterBibleContent(project, artifacts);
+    const { jsPDF } = await import('jspdf');
+    const doc = new jsPDF({ unit: 'pt', format: 'letter' });
+    const margin = 48;
+    const pageWidth = doc.internal.pageSize.getWidth();
+    const pageHeight = doc.internal.pageSize.getHeight();
+    let cursorY = margin;
+
+    const ensureSpace = (height: number) => {
+        if (cursorY + height > pageHeight - margin) {
+            doc.addPage();
+            cursorY = margin;
+        }
+    };
+
+    const writeHeading = (text: string) => {
+        ensureSpace(28);
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(20);
+        doc.text(text, margin, cursorY);
+        cursorY += 28;
+    };
+
+    const writeSectionHeading = (text: string) => {
+        ensureSpace(24);
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(16);
+        doc.text(text, margin, cursorY);
+        cursorY += 24;
+    };
+
+    const writeSubsectionHeading = (text: string) => {
+        ensureSpace(20);
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(13);
+        doc.text(text, margin, cursorY);
+        cursorY += 20;
+    };
+
+    const writeMinorHeading = (text: string) => {
+        ensureSpace(18);
+        doc.setFont('helvetica', 'bold');
+        doc.setFontSize(12);
+        doc.text(text, margin, cursorY);
+        cursorY += 18;
+    };
+
+    const writeParagraph = (
+        text: string,
+        options: { fontSize?: number; fontStyle?: 'normal' | 'bold' | 'italic'; spacingAfter?: number } = {},
+    ) => {
+        if (!text) {
+            return;
+        }
+        const { fontSize = 11, fontStyle = 'normal', spacingAfter = 12 } = options;
+        const maxWidth = pageWidth - margin * 2;
+        const lines = doc.splitTextToSize(text, maxWidth);
+        doc.setFont('helvetica', fontStyle);
+        doc.setFontSize(fontSize);
+        lines.forEach((line) => {
+            ensureSpace(14);
+            doc.text(line, margin, cursorY);
+            cursorY += 14;
+        });
+        cursorY += spacingAfter;
+    };
+
+    const writeList = (items: string[]) => {
+        if (items.length === 0) {
+            return;
+        }
+        const maxWidth = pageWidth - margin * 2 - 16;
+        doc.setFont('helvetica', 'normal');
+        doc.setFontSize(11);
+        items.forEach((item) => {
+            const lines = doc.splitTextToSize(item, maxWidth);
+            const blockHeight = lines.length * 14 + 6;
+            ensureSpace(blockHeight);
+            doc.text('•', margin, cursorY);
+            lines.forEach((line, index) => {
+                doc.text(line, margin + 12, cursorY);
+                if (index < lines.length - 1) {
+                    cursorY += 14;
+                }
+            });
+            cursorY += 18;
+        });
+    };
+
+    const formatRelations = (relations: ResolvedRelation[]) => relations.map(formatRelationForMarkdown);
+
+    writeHeading(`${content.project.title} — Chapter Bible`);
+    writeParagraph(`Summary: ${content.project.summary || 'No summary recorded.'}`);
+    if (content.project.tags.length > 0) {
+        writeParagraph(`Tags: ${content.project.tags.join(', ')}`);
+    }
+    writeParagraph(`Generated on ${new Date().toLocaleString()}`, { fontSize: 10, fontStyle: 'italic', spacingAfter: 16 });
+
+    if (content.storylines.length > 0) {
+        writeSectionHeading('Storylines & Scenes');
+        content.storylines.forEach((storyline) => {
+            writeSubsectionHeading(`${storyline.title} (${storyline.type})`);
+            writeParagraph(storyline.summary ?? '');
+            const details = [`Status: ${storyline.status}`];
+            if (storyline.tags.length > 0) {
+                details.push(`Tags: ${storyline.tags.join(', ')}`);
+            }
+            writeParagraph(details.join(' • '));
+            if (storyline.scenes.length > 0) {
+                writeMinorHeading('Scenes');
+                writeList(
+                    storyline.scenes.map((scene, index) => {
+                        const suffix = scene.summary ? ` — ${scene.summary}` : '';
+                        return `${index + 1}. ${scene.title}${suffix}`;
+                    }),
+                );
+            }
+            if (storyline.relations.length > 0) {
+                writeMinorHeading('Relations');
+                writeList(formatRelations(storyline.relations));
+            }
+            cursorY += 6;
+        });
+    }
+
+    if (content.chapters.length > 0) {
+        writeSectionHeading('Chapters');
+        content.chapters.forEach((chapter) => {
+            writeSubsectionHeading(chapter.title);
+            writeParagraph(chapter.summary ?? '');
+            const details = [`Status: ${chapter.status}`];
+            if (chapter.tags.length > 0) {
+                details.push(`Tags: ${chapter.tags.join(', ')}`);
+            }
+            writeParagraph(details.join(' • '));
+            if (chapter.relations.length > 0) {
+                writeMinorHeading('Relations');
+                writeList(formatRelations(chapter.relations));
+            }
+            cursorY += 6;
+        });
+    }
+
+    if (content.characters.length > 0) {
+        writeSectionHeading('Characters');
+        content.characters.forEach((character) => {
+            writeSubsectionHeading(character.title);
+            writeParagraph(character.summary ?? '');
+            const details = [`Status: ${character.status}`];
+            if (character.tags.length > 0) {
+                details.push(`Tags: ${character.tags.join(', ')}`);
+            }
+            writeParagraph(details.join(' • '));
+            if (character.bio) {
+                writeMinorHeading('Biography');
+                writeParagraph(character.bio);
+            }
+            if (character.traits.length > 0) {
+                writeMinorHeading('Traits');
+                writeList(character.traits.map((trait) => `${trait.key}: ${trait.value}`));
+            }
+            if (character.relations.length > 0) {
+                writeMinorHeading('Relations');
+                writeList(formatRelations(character.relations));
+            }
+            cursorY += 6;
+        });
+    }
+
+    if (content.locations.length > 0) {
+        writeSectionHeading('Locations');
+        content.locations.forEach((location) => {
+            writeSubsectionHeading(location.title);
+            writeParagraph(location.summary ?? '');
+            const details = [`Status: ${location.status}`];
+            if (location.tags.length > 0) {
+                details.push(`Tags: ${location.tags.join(', ')}`);
+            }
+            writeParagraph(details.join(' • '));
+            if (location.description) {
+                writeMinorHeading('Description');
+                writeParagraph(location.description);
+            }
+            if (location.features.length > 0) {
+                writeMinorHeading('Notable Features');
+                writeList(location.features.map((feature) => `${feature.name}: ${feature.description}`));
+            }
+            if (location.relations.length > 0) {
+                writeMinorHeading('Relations');
+                writeList(formatRelations(location.relations));
+            }
+            cursorY += 6;
+        });
+    }
+
+    if (content.timelineEntries.length > 0) {
+        writeSectionHeading('Timelines');
+        content.timelineEntries.forEach((timeline) => {
+            writeSubsectionHeading(timeline.title);
+            writeParagraph(timeline.summary ?? '');
+            if (timeline.events.length > 0) {
+                writeList(
+                    timeline.events.map((event) => {
+                        const detail = event.description ? ` — ${event.description}` : '';
+                        return `${event.date}: ${event.title}${detail}`;
+                    }),
+                );
+            }
+            cursorY += 6;
+        });
+    }
+
+    if (content.terminology.length > 0) {
+        writeSectionHeading('Terminology & Glossary');
+        writeList(
+            content.terminology.map((entry) => {
+                const relationSummary = entry.relations.map(formatRelationForMarkdown).join(' • ');
+                const tagSummary = entry.tags.length > 0 ? ` [${entry.tags.join(', ')}]` : '';
+                return `${entry.title}${tagSummary}: ${entry.summary || 'No definition captured yet.'}${
+                    relationSummary ? ` — ${relationSummary}` : ''
+                }`;
+            }),
+        );
+    }
+
+    if (content.lexicon.length > 0) {
+        writeSectionHeading('Lexicon');
+        writeList(
+            content.lexicon.map((lexeme) => {
+                const etymology = lexeme.etymology ? ` · ${lexeme.etymology}` : '';
+                return `${lexeme.language}: ${lexeme.lemma} (${lexeme.pos}) — ${lexeme.gloss}${etymology}`;
+            }),
+        );
+    }
+
+    if (content.wikiPages.length > 0) {
+        writeSectionHeading('Wiki Pages');
+        content.wikiPages.forEach((wiki) => {
+            writeSubsectionHeading(wiki.title);
+            writeParagraph(wiki.summary ?? '');
+            writeParagraph(wiki.content ?? '', { spacingAfter: 16 });
+        });
+    }
+
+    if (content.gameModules.length > 0) {
+        writeSectionHeading('Game Modules');
+        content.gameModules.forEach((module) => {
+            writeSubsectionHeading(module.title);
+            writeParagraph(module.summary ?? '');
+            const details = [`Status: ${module.status}`];
+            if (module.tags.length > 0) {
+                details.push(`Tags: ${module.tags.join(', ')}`);
+            }
+            writeParagraph(details.join(' • '));
+            if (module.relations.length > 0) {
+                writeMinorHeading('Relations');
+                writeList(formatRelations(module.relations));
+            }
+            cursorY += 6;
+        });
+    }
+
+    doc.save(`${slugifyForFilename(project.title)}_chapter_bible.pdf`);
+};
+
+export const createLoreJsonPayload = (content: ChapterBibleContent) => {
+    const mapRelations = (relations: ResolvedRelation[]) =>
+        relations.map((relation) => ({
+            kind: relation.kind,
+            targetId: relation.targetId,
+            targetTitle: relation.targetTitle,
+            targetType: relation.targetType,
+        }));
+
+    return {
+        metadata: {
+            projectId: content.project.id,
+            projectTitle: content.project.title,
+            summary: content.project.summary,
+            tags: content.project.tags,
+            exportedAt: new Date().toISOString(),
+        },
+        narrative: {
+            storylines: content.storylines.map((storyline) => ({
+                id: storyline.id,
+                title: storyline.title,
+                type: storyline.type,
+                status: storyline.status,
+                summary: storyline.summary,
+                tags: storyline.tags,
+                scenes: storyline.scenes.map((scene, index) => ({
+                    id: scene.id,
+                    title: scene.title,
+                    summary: scene.summary,
+                    order: index + 1,
+                })),
+                relations: mapRelations(storyline.relations),
+            })),
+            chapters: content.chapters.map((chapter) => ({
+                id: chapter.id,
+                title: chapter.title,
+                status: chapter.status,
+                summary: chapter.summary,
+                tags: chapter.tags,
+                relations: mapRelations(chapter.relations),
+            })),
+            timeline: content.timelineEntries.map((timeline) => ({
+                id: timeline.id,
+                title: timeline.title,
+                summary: timeline.summary,
+                events: timeline.events.map((event) => ({
+                    id: event.id,
+                    date: event.date,
+                    title: event.title,
+                    description: event.description,
+                })),
+            })),
+        },
+        lore: {
+            characters: content.characters.map((character) => ({
+                id: character.id,
+                name: character.title,
+                status: character.status,
+                summary: character.summary,
+                tags: character.tags,
+                bio: character.bio,
+                traits: character.traits.map((trait) => ({ key: trait.key, value: trait.value })),
+                relations: mapRelations(character.relations),
+            })),
+            locations: content.locations.map((location) => ({
+                id: location.id,
+                title: location.title,
+                status: location.status,
+                summary: location.summary,
+                tags: location.tags,
+                description: location.description,
+                features: location.features.map((feature) => ({
+                    id: feature.id,
+                    name: feature.name,
+                    description: feature.description,
+                })),
+                relations: mapRelations(location.relations),
+            })),
+            terminology: content.terminology.map((entry) => ({
+                id: entry.id,
+                title: entry.title,
+                summary: entry.summary,
+                tags: entry.tags,
+                relations: mapRelations(entry.relations),
+            })),
+            wikiPages: content.wikiPages.map((wiki) => ({
+                id: wiki.id,
+                title: wiki.title,
+                summary: wiki.summary,
+                content: wiki.content,
+            })),
+            lexicon: content.lexicon.map((lexeme) => ({
+                id: lexeme.id,
+                language: lexeme.language,
+                lemma: lexeme.lemma,
+                partOfSpeech: lexeme.pos,
+                gloss: lexeme.gloss,
+                etymology: lexeme.etymology ?? null,
+                tags: lexeme.tags ?? [],
+                sourceArtifactId: lexeme.artifactId,
+            })),
+        },
+        ackModule: {
+            modules: content.gameModules.map((module) => ({
+                id: module.id,
+                title: module.title,
+                status: module.status,
+                summary: module.summary,
+                tags: module.tags,
+                relations: mapRelations(module.relations),
+            })),
+        },
+    };
+};
+
+export const exportLoreJson = (project: Project, artifacts: Artifact[]) => {
+    const content = buildChapterBibleContent(project, artifacts);
+    const payload = createLoreJsonPayload(content);
+    const filename = `${slugifyForFilename(project.title)}_lore.json`;
+    triggerBlobDownload(new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json;charset=utf-8;' }), filename);
 };
 
 const exportArtifactsToDelimitedFile = (artifacts: Artifact[], projectName: string, delimiter: string, extension: string) => {

--- a/docs/product-roadmap.md
+++ b/docs/product-roadmap.md
@@ -15,7 +15,7 @@ The “Organize My Worlds Without Pain” release.
 - [x] Rich text editor with Markdown and AI assist.
 - [x] Relationship graph linking characters ↔ events ↔ worlds.
 - [x] Import pipelines for Markdown and text dumps (chat, drafts).
-- [ ] Export pipelines for chapter bible PDF/Markdown and lore JSON for game engines (Dustland ACK modules).
+- [x] Export pipelines for chapter bible PDF/Markdown and lore JSON for game engines (Dustland ACK modules).
 - [x] "Add one fact" button to reduce overwhelm.
 - [x] World dashboards to add lore, visualize connections, and link crossover projects (Dustland NPC ←→ Sacred Truth vampire cameo).
 - [x] "Reveal depth" toggle for simple → detailed fields.

--- a/issue-drafts/001-product-roadmap-phase-1-core-lore-os-mvp-export-pipelines-for-chapter-bible-pdfm.md
+++ b/issue-drafts/001-product-roadmap-phase-1-core-lore-os-mvp-export-pipelines-for-chapter-bible-pdfm.md
@@ -7,4 +7,4 @@
 Export pipelines for chapter bible PDF/Markdown and lore JSON for game engines (Dustland ACK modules).
 
 ## Acceptance Criteria
-- [ ] Export pipelines for chapter bible PDF/Markdown and lore JSON for game engines (Dustland ACK modules).
+- [x] Export pipelines for chapter bible PDF/Markdown and lore JSON for game engines (Dustland ACK modules).


### PR DESCRIPTION
## Summary
- add lore aggregation utilities to export chapter bibles as Markdown and PDF plus Dustland-ready lore JSON
- expose new export buttons in the project toolbar and document the completed roadmap item
- cover the aggregation logic with unit tests and add jspdf dependency for PDF generation

## Testing
- npm run lint --prefix code
- npm run test --prefix code

------
https://chatgpt.com/codex/tasks/task_e_6905b04d797c8328aa5e46b56bd2e53f