### PR TITLE
Fix duplicate memoized project selectors in App

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1302,11 +1302,7 @@ export default function App() {
   const [isPublishModalOpen, setIsPublishModalOpen] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
   const dataApiEnabled = isDataApiConfigured && !isGuestMode;
-  const selectedProject = useMemo(() => projects.find((project) => project.id === selectedProjectId), [projects, selectedProjectId]);
-  const projectArtifacts = useMemo(
-    () => artifacts.filter((artifact) => artifact.projectId === selectedProjectId),
-    [artifacts, selectedProjectId],
-  );
+  
   const triggerDownload = useCallback((blob: Blob, filename: string) => {
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -1897,36 +1893,6 @@ export default function App() {
       setIsPublishing(false);
     }
   };
-
-  const visibleProjects = useMemo(() => {
-    const normalizedQuery = projectSearchTerm.trim().toLowerCase();
-
-    return projects.filter((project) => {
-      if (projectStatusFilter !== 'ALL' && project.status !== projectStatusFilter) {
-        return false;
-      }
-
-      if (normalizedQuery) {
-        const haystack = `${project.title} ${project.summary} ${project.tags.join(' ')}`.toLowerCase();
-        if (!haystack.includes(normalizedQuery)) {
-          return false;
-        }
-      }
-
-      return true;
-    });
-  }, [projects, projectStatusFilter, projectSearchTerm]);
-  const quickFacts = useMemo(() => {
-    if (!selectedProjectId) {
-      return [];
-    }
-    return projectArtifacts.filter(isQuickFactArtifact).slice().sort(sortQuickFactsByRecency);
-  }, [projectArtifacts, selectedProjectId]);
-  const quickFactPreview = useMemo(() => quickFacts.slice(0, 4), [quickFacts]);
-  const hasProjectFilters = projectStatusFilter !== 'ALL' || projectSearchTerm.trim() !== '';
-  const selectedProjectHiddenBySidebarFilters = Boolean(
-    selectedProjectId && !visibleProjects.some((project) => project.id === selectedProjectId),
-  );
 
   const handleResetProjectFilters = useCallback(() => {
     setProjectStatusFilter('ALL');


### PR DESCRIPTION
## Summary
- remove redundant memoized selectors for the active project and related collections in `App.tsx`
- rely on a single set of memoized values for project filters to avoid redeclaration issues

## Testing
- npm run lint --prefix .

------
https://chatgpt.com/codex/tasks/task_e_6905b315db5c8328b97458dd1eda780a