### PR TITLE
feat: Configure and document GitHub OAuth flow

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -86,6 +86,12 @@ jobs:
         uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
+      - name: Inject secrets into app.yaml
+        run: |
+          sed -i "s/GITHUB_CLIENT_ID: .*/GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}/" app.yaml
+          sed -i "s/GITHUB_CLIENT_SECRET: .*/GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}/" app.yaml
+          sed -i "s/APP_BASE_URL: .*/APP_BASE_URL: ${{ secrets.APP_BASE_URL }}/" app.yaml
+        working-directory: server
       - name: Deploy to App Engine
         run: gcloud app deploy app.yaml --quiet
         working-directory: server

--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ To enable the "Publish to GitHub" feature, you'll need to create a GitHub OAuth 
     *   Click "New OAuth App".
     *   **Application name:** "Creative Atlas (local)" or similar.
     *   **Homepage URL:** The URL of your frontend application (e.g., `http://localhost:5173`).
-    *   **Authorization callback URL:** The callback URL for your backend API. For local development, this should be `http://localhost:5173/api/github/oauth/callback`. *Note: The frontend Vite server will proxy this to the backend.*
+    *   **Authorization callback URL:** This URL must point to your backend's OAuth callback endpoint.
+        *   For **local development**, use `http://localhost:5173/api/github/oauth/callback`. The Vite frontend server will proxy this to your local backend.
+        *   For a **production deployment**, use the public URL of your application, e.g., `https://creative-atlas.web.app/api/github/oauth/callback`. You may need to create a separate GitHub OAuth App for your production environment.
 
 2.  **Configure Environment Variables:**
     *   In the `server/` directory, copy the `.env.example` file to a new file named `.env`:

--- a/server/app.yaml
+++ b/server/app.yaml
@@ -5,7 +5,7 @@ entrypoint: npm start
 
 env_variables:
   NODE_ENV: production
-  ALLOWED_ORIGins: https://creative-atlas.web.app
-  GITHUB_CLIENT_ID: ${{ GITHUB_CLIENT_ID }}
-  GITHUB_CLIENT_SECRET: ${{ GITHUB_CLIENT_SECRET }}
-  APP_BASE_URL: ${{ APP_BASE_URL }}
+  ALLOWED_ORIGINS: https://creative-atlas.web.app
+  GITHUB_CLIENT_ID: "placeholder"
+  GITHUB_CLIENT_SECRET: "placeholder"
+  APP_BASE_URL: "placeholder"


### PR DESCRIPTION
This commit fully configures the "Publish to GitHub" feature by documenting the required setup for both local development and production deployment.

- Adds a `server/.env.example` file to specify the necessary environment variables (`GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `APP_BASE_URL`).
- Updates `server/app.yaml` to include these environment variables, allowing them to be passed to the Google App Engine runtime.
- Expands `README.md` with detailed instructions for:
  - Creating a GitHub OAuth application.
  - Setting up the `server/.env` file for local development.
  - Configuring repository secrets in GitHub Actions for secure deployment to production.