### PR TITLE
Secure session secret and align GitHub env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,10 +94,11 @@ To enable the "Publish to GitHub" feature, you'll need to create a GitHub OAuth 
         ```bash
         cp server/.env.example server/.env
         ```
-    *   Open `server/.env` and fill in the following values from your GitHub OAuth app:
+    *   Open `server/.env` and fill in the following values:
         *   `CA_GITHUB_CLIENT_ID`: The "Client ID" of your GitHub OAuth app.
         *   `CA_GITHUB_CLIENT_SECRET`: The "Client Secret" of your GitHub OAuth app.
         *   `APP_BASE_URL`: The base URL of your frontend application (e.g., `http://localhost:5173`).
+        *   `SESSION_SECRET`: A long, random string used to sign user sessions. Generate one with `openssl rand -hex 32`.
 
 3.  **Configure Deployment Secrets:**
     *   For the GitHub integration to work in the deployed application, you must also configure these variables as secrets in your GitHub repository.
@@ -106,6 +107,7 @@ To enable the "Publish to GitHub" feature, you'll need to create a GitHub OAuth 
         *   `CA_GITHUB_CLIENT_ID`: The Client ID from your OAuth app.
         *   `CA_GITHUB_CLIENT_SECRET`: The Client Secret from your OAuth app.
         *   `APP_BASE_URL`: The public URL of your deployed frontend application (e.g., `https://creative-atlas.web.app`).
+        *   `SESSION_SECRET`: Match the secret configured for your production deployment.
 
     The GitHub Actions deployment workflow will use these secrets to configure the App Engine environment.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,8 +1,12 @@
 # GitHub OAuth Application settings
 # You can create a new OAuth app here: https://github.com/settings/developers
-GITHUB_CLIENT_ID=your_github_client_id
-GITHUB_CLIENT_SECRET=your_github_client_secret
+CA_GITHUB_CLIENT_ID=your_github_client_id
+CA_GITHUB_CLIENT_SECRET=your_github_client_secret
 
 # The base URL of your application, used for OAuth redirect URIs
 # For local development, this will typically be http://localhost:5173
 APP_BASE_URL=http://localhost:5173
+
+# Session configuration
+# Generate a strong secret (e.g., `openssl rand -hex 32`) before deploying to production
+SESSION_SECRET=change_me

--- a/server/app.yaml
+++ b/server/app.yaml
@@ -9,3 +9,4 @@ env_variables:
   CA_GITHUB_CLIENT_ID: "placeholder"
   CA_GITHUB_CLIENT_SECRET: "placeholder"
   APP_BASE_URL: "placeholder"
+  SESSION_SECRET: "replace_me"

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -9,6 +9,18 @@ const allowedOrigins = (process.env.ALLOWED_ORIGINS ?? 'https://creative-atlas.w
   .split(',')
   .map((origin) => origin.trim());
 
+const sessionSecret = process.env.SESSION_SECRET;
+
+if (!sessionSecret) {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error('SESSION_SECRET must be set in production environments.');
+  }
+
+  console.warn(
+    'SESSION_SECRET is not set; using an insecure fallback secret for development.',
+  );
+}
+
 const corsOptions: CorsOptions = {
   origin: (origin, callback) => {
     if (!origin || allowedOrigins.includes(origin)) {
@@ -30,7 +42,7 @@ app.options('*', cors(corsOptions));
 app.use(express.json({ limit: '5mb' }));
 app.use(morgan('dev'));
 app.use(session({
-  secret: 'keyboard cat', // TODO: Use a real secret
+  secret: sessionSecret ?? 'development-insecure-secret',
   resave: false,
   saveUninitialized: true,
   cookie: {

--- a/server/src/routes/github.ts
+++ b/server/src/routes/github.ts
@@ -17,8 +17,16 @@ const router = Router();
 
 router.use(authenticate);
 
-const GITHUB_CLIENT_ID = process.env.GITHUB_CLIENT_ID;
-const GITHUB_CLIENT_SECRET = process.env.GITHUB_CLIENT_SECRET;
+const GITHUB_CLIENT_ID =
+  process.env.CA_GITHUB_CLIENT_ID ?? process.env.GITHUB_CLIENT_ID;
+const GITHUB_CLIENT_SECRET =
+  process.env.CA_GITHUB_CLIENT_SECRET ?? process.env.GITHUB_CLIENT_SECRET;
+
+if (!GITHUB_CLIENT_ID || !GITHUB_CLIENT_SECRET) {
+  throw new Error(
+    'GitHub OAuth credentials are not configured. Set CA_GITHUB_CLIENT_ID and CA_GITHUB_CLIENT_SECRET.',
+  );
+}
 
 const createGithubAuthUrl = (req: AuthenticatedRequest): string => {
   const state = crypto.randomBytes(16).toString('hex');


### PR DESCRIPTION
## Summary
- require a configured SESSION_SECRET in production while providing a development fallback and documenting it in env templates
- support the CA_GITHUB_* environment variable names for the OAuth flow and fail fast when credentials are missing
- update deployment configuration and README instructions to reflect the new settings

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_69063dd88b8883289ae432d81d889df3