### PR TITLE
Fix jspdf resolution for Vite builds

### DIFF
--- a/code/vite.config.ts
+++ b/code/vite.config.ts
@@ -1,11 +1,21 @@
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
+const jspdfEsmPath = 'jspdf/dist/jspdf.es.min.js';
+
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   return {
     plugins: [react()],
+    resolve: {
+      alias: {
+        jspdf: jspdfEsmPath,
+      },
+    },
+    optimizeDeps: {
+      include: ['jspdf'],
+    },
     server: {
       proxy: {
         '/api': {


### PR DESCRIPTION
## Summary
- ensure Vite resolves jspdf to the package's ESM build and prebundle it during dev
- configure dependency optimization so jspdf is available when exporting PDFs

## Testing
- npm run lint --prefix code
- npm run build --prefix code
- npm test --prefix code

------
https://chatgpt.com/codex/tasks/task_e_69063f130f0c8328b108940c389c825e