### PR TITLE
Adjust triangle toggle icon orientation

### DIFF
--- a/code/components/Icons.tsx
+++ b/code/components/Icons.tsx
@@ -155,8 +155,8 @@ export const ChevronDownIcon: React.FC<{ className?: string }> = ({ className })
 );
 
 export const TriangleToggleIcon: React.FC<{ className?: string }> = ({ className }) => (
-  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 12' fill='currentColor' className={className}>
-    <path d='M3 2.5L21 6 3 9.5z' />
+  <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 12 7' fill='currentColor' className={className}>
+    <path d='M6 7L0 0h12L6 7z' />
   </svg>
 );
 

--- a/code/components/UserProfileCard.tsx
+++ b/code/components/UserProfileCard.tsx
@@ -106,7 +106,9 @@ const UserProfileCard: React.FC<UserProfileCardProps> = ({ profile, onUpdateProf
               aria-controls={preferencesPanelId}
             >
               <TriangleToggleIcon
-                className={`h-3.5 w-3.5 transition-transform duration-300 ease-in-out ${isExpanded ? 'rotate-90' : 'rotate-0'}`}
+                className={`h-3.5 w-3.5 transition-transform duration-300 ease-in-out ${
+                  isExpanded ? 'rotate-180' : 'rotate-0'
+                }`}
               />
             </button>
           </div>


### PR DESCRIPTION
## Summary
- update the triangle toggle SVG to render as a short, wide chevron suited for Zippy sections
- adjust the UserProfileCard expand button rotation to keep its indicator direction correct

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_6907fdcfc47083288f4b4c278f637f49