### PR TITLE
Add clipboard copy support to quick facts panel

### DIFF
--- a/code/components/QuickFactsPanel.tsx
+++ b/code/components/QuickFactsPanel.tsx
@@ -36,6 +36,39 @@ const createFactPreview = (artifact: Artifact): { fact: string; detail: string |
   };
 };
 
+type CopyStatus = {
+  id: string;
+  status: 'copied' | 'error';
+};
+
+const writeTextToClipboard = async (text: string) => {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  if (typeof document === 'undefined') {
+    throw new Error('Clipboard APIs are not available.');
+  }
+
+  const textarea = document.createElement('textarea');
+  textarea.value = text;
+  textarea.setAttribute('readonly', '');
+  textarea.style.position = 'absolute';
+  textarea.style.left = '-9999px';
+  document.body.appendChild(textarea);
+  textarea.select();
+  if (typeof textarea.setSelectionRange === 'function') {
+    textarea.setSelectionRange(0, textarea.value.length);
+  }
+  const successful = document.execCommand('copy');
+  document.body.removeChild(textarea);
+
+  if (!successful) {
+    throw new Error('Copy command was unsuccessful.');
+  }
+};
+
 const QuickFactsPanel: React.FC<QuickFactsPanelProps> = ({
   facts,
   totalFacts,
@@ -44,6 +77,62 @@ const QuickFactsPanel: React.FC<QuickFactsPanelProps> = ({
   onAddFact,
 }) => {
   const hasFacts = facts.length > 0;
+  const [copyStatus, setCopyStatus] = React.useState<CopyStatus | null>(null);
+
+  React.useEffect(() => {
+    if (!copyStatus || typeof window === 'undefined') {
+      return;
+    }
+
+    const timeout = window.setTimeout(() => {
+      setCopyStatus(null);
+    }, 2400);
+
+    return () => window.clearTimeout(timeout);
+  }, [copyStatus]);
+
+  const handleCopyFact = async (artifact: Artifact) => {
+    const preview = createFactPreview(artifact);
+    const segments: string[] = [];
+    const trimmedTitle = artifact.title.trim();
+    const trimmedFact = preview.fact.trim();
+    const trimmedDetail = preview.detail?.trim();
+
+    if (trimmedTitle.length > 0) {
+      segments.push(trimmedTitle);
+    }
+
+    if (trimmedFact.length > 0) {
+      segments.push(trimmedFact);
+    }
+
+    if (trimmedDetail && trimmedDetail.length > 0) {
+      segments.push(trimmedDetail);
+    }
+
+    const textToCopy = segments.join('\n');
+
+    if (textToCopy.length === 0) {
+      setCopyStatus({ id: artifact.id, status: 'error' });
+      return;
+    }
+
+    try {
+      await writeTextToClipboard(textToCopy);
+      setCopyStatus({ id: artifact.id, status: 'copied' });
+    } catch (error) {
+      console.error('Failed to copy quick fact to clipboard.', error);
+      setCopyStatus({ id: artifact.id, status: 'error' });
+    }
+  };
+
+  const getCopyButtonLabel = (artifactId: string) => {
+    if (!copyStatus || copyStatus.id !== artifactId) {
+      return 'Copy fact';
+    }
+
+    return copyStatus.status === 'copied' ? 'Copied!' : 'Retry copy';
+  };
 
   return (
     <section className="rounded-2xl border border-amber-500/30 bg-amber-500/10 p-6 shadow-lg shadow-amber-500/10">
@@ -79,21 +168,44 @@ const QuickFactsPanel: React.FC<QuickFactsPanelProps> = ({
                   key={artifact.id}
                   className="rounded-xl border border-amber-400/30 bg-slate-950/60 p-4 shadow-inner shadow-amber-500/10"
                 >
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div className="flex flex-col gap-3">
                     <div>
                       <p className="text-sm font-semibold text-amber-100">{artifact.title}</p>
                       <p className="mt-1 text-sm text-amber-100/80">{preview.fact}</p>
                       {preview.detail && (
                         <p className="mt-1 text-xs text-amber-200/70">{preview.detail}</p>
                       )}
+                      {copyStatus?.id === artifact.id && (
+                        <p
+                          aria-live="polite"
+                          className={`mt-2 text-xs ${
+                            copyStatus.status === 'copied'
+                              ? 'text-emerald-300/80'
+                              : 'text-rose-300/80'
+                          }`}
+                        >
+                          {copyStatus.status === 'copied'
+                            ? 'Fact copied to clipboard.'
+                            : 'Unable to reach the clipboard. Try again or copy manually.'}
+                        </p>
+                      )}
                     </div>
-                    <button
-                      type="button"
-                      onClick={() => onSelectFact(artifact.id)}
-                      className="inline-flex items-center justify-center rounded-md border border-amber-400/60 px-3 py-1.5 text-xs font-semibold text-amber-100 transition-colors hover:border-amber-300 hover:text-amber-50"
-                    >
-                      Open fact
-                    </button>
+                    <div className="flex flex-wrap items-center gap-2 sm:justify-end">
+                      <button
+                        type="button"
+                        onClick={() => handleCopyFact(artifact)}
+                        className="inline-flex items-center justify-center rounded-md border border-amber-400/60 px-3 py-1.5 text-xs font-semibold text-amber-100 transition-colors hover:border-amber-300 hover:text-amber-50"
+                      >
+                        {getCopyButtonLabel(artifact.id)}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => onSelectFact(artifact.id)}
+                        className="inline-flex items-center justify-center rounded-md border border-amber-400/60 px-3 py-1.5 text-xs font-semibold text-amber-100 transition-colors hover:border-amber-300 hover:text-amber-50"
+                      >
+                        Open fact
+                      </button>
+                    </div>
                   </div>
                 </li>
               );


### PR DESCRIPTION
## Summary
- add clipboard helper to copy quick facts to the clipboard with graceful fallback
- surface user feedback on copy success or failure and keep the open fact control available

## Testing
- npm run lint --prefix code

## Screenshots
![Quick facts copy control](browser:/invocations/lanqeyou/artifacts/artifacts/quick-facts-copy.png)


------
https://chatgpt.com/codex/tasks/task_e_69084183d2988328aafa872e3bcd0b78