### PR TITLE
Allow closing tutorial with Escape key

### DIFF
--- a/code/components/TutorialGuide.tsx
+++ b/code/components/TutorialGuide.tsx
@@ -24,6 +24,23 @@ const TutorialGuide: React.FC<TutorialGuideProps> = ({ onClose }) => {
     });
   }, [onClose]);
 
+  const handleCancelTutorial = useCallback(
+    (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleCancelTutorial);
+
+    return () => {
+      document.removeEventListener('keydown', handleCancelTutorial);
+    };
+  }, [handleCancelTutorial]);
+
   useEffect(() => {
     const step = tutorialSteps[currentStep];
     if (step.target) {


### PR DESCRIPTION
## Summary
- allow players to dismiss the tutorial by pressing the Escape key
- register a keydown listener that triggers the tutorial close handler

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_69093863db088328a40e7bf4c6fab326