### PR TITLE
Fix GitHub publish flow

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -2032,7 +2032,7 @@ export default function App() {
       const popup = window.open(
         authUrl,
         'creative-atlas-github-oauth',
-        'width=600,height=700,noopener,noreferrer',
+        'width=600,height=700',
       );
 
       if (!popup) {

--- a/server/src/routes/github.ts
+++ b/server/src/routes/github.ts
@@ -221,32 +221,66 @@ router.post('/publish', authenticate, asyncHandler(async (req: AuthenticatedRequ
 
         const distPath = path.resolve('code', 'dist');
 
-        const files = await fs.readdir(distPath, { withFileTypes: true });
+        const sanitizePublishDir = (dir: string | undefined): string | undefined => {
+            if (!dir) {
+                return undefined;
+            }
+            const trimmed = dir.trim().replace(/^\/+|\/+$/g, '');
+            return trimmed.length > 0 ? trimmed : undefined;
+        };
+
+        const normalizedPublishDir = sanitizePublishDir(publishDir);
+
+        const collectFiles = async (
+            directory: string,
+            relativeRoot = '',
+        ): Promise<Array<{ relativePath: string; absolutePath: string }>> => {
+            const entries = await fs.readdir(directory, { withFileTypes: true });
+            const allFiles: Array<{ relativePath: string; absolutePath: string }> = [];
+
+            for (const entry of entries) {
+                const absolutePath = path.join(directory, entry.name);
+                const relativePath = relativeRoot
+                    ? path.posix.join(relativeRoot, entry.name)
+                    : entry.name;
+
+                if (entry.isDirectory()) {
+                    const nested = await collectFiles(absolutePath, relativePath);
+                    allFiles.push(...nested);
+                } else if (entry.isFile()) {
+                    allFiles.push({ relativePath, absolutePath });
+                }
+            }
+
+            return allFiles;
+        };
+
+        const files = await collectFiles(distPath);
         const fileBlobs = [];
 
         for (const file of files) {
-            if (file.isFile()) {
-                const content = await fs.readFile(path.join(distPath, file.name), 'base64');
-                const blobResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/blobs`, {
-                    method: 'POST',
-                    headers: {
-                        'Authorization': `token ${accessToken}`,
-                        'Accept': 'application/vnd.github.v3+json',
-                    },
-                    body: JSON.stringify({
-                        content,
-                        encoding: 'base64',
-                    }),
-                });
-                const blobData = await blobResponse.json();
-                const filePath = publishDir ? path.join(publishDir, file.name) : file.name;
-                fileBlobs.push({
-                    path: filePath,
-                    mode: '100644',
-                    type: 'blob',
-                    sha: blobData.sha,
-                });
-            }
+            const content = await fs.readFile(file.absolutePath, 'base64');
+            const blobResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/blobs`, {
+                method: 'POST',
+                headers: {
+                    'Authorization': `token ${accessToken}`,
+                    'Accept': 'application/vnd.github.v3+json',
+                },
+                body: JSON.stringify({
+                    content,
+                    encoding: 'base64',
+                }),
+            });
+            const blobData = await blobResponse.json();
+            const relativePath = normalizedPublishDir
+                ? path.posix.join(normalizedPublishDir, file.relativePath)
+                : file.relativePath;
+            fileBlobs.push({
+                path: relativePath,
+                mode: '100644',
+                type: 'blob',
+                sha: blobData.sha,
+            });
         }
 
         const treeResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/git/trees`, {
@@ -285,6 +319,25 @@ router.post('/publish', authenticate, asyncHandler(async (req: AuthenticatedRequ
                 sha: commitData.sha,
             }),
         });
+
+        const enablePagesResponse = await fetch(`https://api.github.com/repos/${owner}/${repo}/pages`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `token ${accessToken}`,
+                'Accept': 'application/vnd.github+json',
+            },
+            body: JSON.stringify({
+                source: {
+                    branch: 'gh-pages',
+                    path: '/',
+                },
+            }),
+        });
+
+        if (!enablePagesResponse.ok) {
+            const errorText = await enablePagesResponse.text();
+            console.error('Error enabling GitHub Pages:', errorText);
+        }
 
         console.log('Successfully published to GitHub Pages!');
     });


### PR DESCRIPTION
## Summary
- allow the GitHub OAuth popup to keep its opener so the authorization success message reaches the app and re-opens the publish modal
- export the built site recursively, honor optional publish directories, and enable GitHub Pages after pushing the gh-pages branch

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_690ab9b65c5c8328ac3ee84ffe649d66