### PR TITLE
Fix GitHub publish modal not opening after OAuth

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -1406,20 +1406,33 @@ export default function App() {
         return;
       }
 
-      const data = event.data;
-      if (!data || typeof data !== 'object') {
+      let payload: unknown = event.data;
+
+      if (typeof payload === 'string') {
+        try {
+          payload = JSON.parse(payload);
+        } catch (error) {
+          console.warn('Received non-JSON GitHub OAuth message', error);
+          return;
+        }
+      }
+
+      if (!payload || typeof payload !== 'object') {
         return;
       }
 
-      const payload = data as { type?: unknown; status?: unknown; message?: unknown };
-      if (payload.type !== 'github-oauth') {
+      const messagePayload = payload as { type?: unknown; status?: unknown; message?: unknown };
+      if (messagePayload.type !== 'github-oauth') {
         return;
       }
 
-      if (payload.status === 'success') {
+      if (messagePayload.status === 'success') {
         setIsPublishModalOpen(true);
-      } else if (payload.status === 'error') {
-        const message = typeof payload.message === 'string' ? payload.message : 'GitHub authorization failed.';
+      } else if (messagePayload.status === 'error') {
+        const message =
+          typeof messagePayload.message === 'string'
+            ? messagePayload.message
+            : 'GitHub authorization failed.';
         alert(message);
       }
     };


### PR DESCRIPTION
## Summary
- handle GitHub OAuth popup messages that arrive as JSON strings before validating their contents
- continue surfacing the publish modal on success and show the existing error alert on failure

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_690bb5d299cc8328af20b51c49b76c3d