### PR TITLE
Add world simulation intelligence panel

### DIFF
--- a/code/App.tsx
+++ b/code/App.tsx
@@ -82,6 +82,7 @@ import InspirationDeck from './components/InspirationDeck';
 import NarrativePipelineBoard from './components/NarrativePipelineBoard';
 import { createBlankMagicSystemData, createTamenzutMagicSystemData } from './utils/magicSystem';
 import Zippy from './components/Zippy';
+import WorldSimulationPanel from './components/WorldSimulationPanel';
 
 const countArtifactsByType = (artifacts: Artifact[], type: ArtifactType) =>
   artifacts.filter((artifact) => artifact.type === type).length;
@@ -2678,6 +2679,11 @@ export default function App() {
               <MemorySyncPanel
                 conversations={projectConversations}
                 onStatusChange={handleMemoryStatusChange}
+              />
+              <WorldSimulationPanel
+                projectTitle={selectedProject.title}
+                artifacts={projectArtifacts}
+                onSelectArtifact={setSelectedArtifactId}
               />
               <CollapsibleSection
                 title="Project Insights"

--- a/code/components/WorldSimulationPanel.tsx
+++ b/code/components/WorldSimulationPanel.tsx
@@ -1,0 +1,255 @@
+import React, { useMemo } from 'react';
+import { Artifact } from '../types';
+import {
+  ConstraintAnnotation,
+  ConstraintStatus,
+  ConstraintType,
+  FactionConflictSummary,
+  FactionStability,
+  WorldAgeProgression,
+  deriveWorldSimulationSnapshot,
+} from '../utils/worldSimulation';
+import { AlertTriangleIcon, FlagIcon, MapPinIcon, SparklesIcon } from './Icons';
+
+interface WorldSimulationPanelProps {
+  projectTitle: string;
+  artifacts: Artifact[];
+  onSelectArtifact: (artifactId: string) => void;
+}
+
+const STATUS_STYLE: Record<ConstraintStatus, string> = {
+  stable: 'bg-emerald-500/10 text-emerald-200 border-emerald-400/40',
+  volatile: 'bg-amber-500/10 text-amber-200 border-amber-400/50',
+  forbidden: 'bg-rose-500/10 text-rose-200 border-rose-500/50',
+  unknown: 'bg-slate-700/60 text-slate-300 border-slate-600/60',
+};
+
+const TYPE_LABEL: Record<ConstraintType, string> = {
+  physics: 'Physics',
+  metaphysics: 'Metaphysics',
+};
+
+const STABILITY_STYLE: Record<FactionStability, string> = {
+  stable: 'bg-emerald-500/10 text-emerald-200 border-emerald-400/40',
+  shifting: 'bg-amber-500/10 text-amber-200 border-amber-400/40',
+  volatile: 'bg-rose-500/10 text-rose-200 border-rose-500/50',
+};
+
+const WorldSimulationPanel: React.FC<WorldSimulationPanelProps> = ({ projectTitle, artifacts, onSelectArtifact }) => {
+  const snapshot = useMemo(() => deriveWorldSimulationSnapshot(artifacts), [artifacts]);
+  const { constraints, ageProgression, factions } = snapshot;
+
+  return (
+    <section className="bg-slate-900/60 border border-slate-700/60 rounded-2xl p-6 space-y-6">
+      <header className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div className="flex items-start gap-3">
+          <div className="rounded-xl bg-cyan-500/20 border border-cyan-400/40 p-2 text-cyan-200">
+            <SparklesIcon className="w-6 h-6" />
+          </div>
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wide text-cyan-300/90">World Simulation</p>
+            <h3 className="text-xl font-semibold text-slate-100">Systems pulse in {projectTitle}</h3>
+            <p className="text-sm text-slate-400">
+              Track the rules that govern reality, how time is aging the world, and which factions are ready to spark conflict.
+            </p>
+          </div>
+        </div>
+      </header>
+
+      <div className="grid grid-cols-1 gap-6 xl:grid-cols-3">
+        <ConstraintColumn constraints={constraints} onSelectArtifact={onSelectArtifact} />
+        <AgeColumn ageProgression={ageProgression} />
+        <FactionColumn factions={factions} onSelectArtifact={onSelectArtifact} />
+      </div>
+    </section>
+  );
+};
+
+const ConstraintColumn: React.FC<{
+  constraints: ConstraintAnnotation[];
+  onSelectArtifact: (artifactId: string) => void;
+}> = ({ constraints, onSelectArtifact }) => (
+  <div className="space-y-4">
+    <div className="flex items-center gap-2 text-slate-200">
+      <AlertTriangleIcon className="w-5 h-5 text-amber-300" />
+      <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Constraint annotations</h4>
+    </div>
+    <div className="space-y-3">
+      {constraints.length === 0 ? (
+        <p className="text-sm text-slate-400">
+          No simulation constraints flagged yet. Build timelines, locations, or magic codices to surface tensions.
+        </p>
+      ) : (
+        constraints.map((constraint) => (
+          <article
+            key={constraint.id}
+            className="rounded-xl border border-slate-700/60 bg-slate-900/70 p-4 space-y-3 shadow-lg shadow-slate-950/20"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="space-y-1">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-semibold uppercase tracking-wide border ${STATUS_STYLE[constraint.status]}`}
+                  >
+                    {constraint.status === 'stable' ? 'Stable' : constraint.status === 'unknown' ? 'Unknown' : constraint.status}
+                  </span>
+                  <span className="inline-flex items-center gap-1 rounded-full border border-slate-600/60 bg-slate-800/60 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-wide text-slate-300">
+                    {TYPE_LABEL[constraint.type]}
+                  </span>
+                </div>
+                <h5 className="text-base font-semibold text-slate-100">{constraint.label}</h5>
+                <p className="text-sm text-slate-300">{constraint.summary}</p>
+                {constraint.detail && <p className="text-xs text-slate-500">{constraint.detail}</p>}
+              </div>
+              {constraint.relatedArtifactIds.length > 0 && (
+                <button
+                  type="button"
+                  onClick={() => onSelectArtifact(constraint.relatedArtifactIds[0]!)}
+                  className="text-xs font-semibold text-cyan-300 hover:text-cyan-200"
+                >
+                  View
+                </button>
+              )}
+            </div>
+          </article>
+        ))
+      )}
+    </div>
+  </div>
+);
+
+const AgeColumn: React.FC<{ ageProgression: WorldAgeProgression }> = ({ ageProgression }) => {
+  const { currentAge, upcomingAge, eras, lastRecordedYear } = ageProgression;
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 text-slate-200">
+        <MapPinIcon className="w-5 h-5 text-violet-300" />
+        <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-300">World age progression</h4>
+      </div>
+      {eras.length === 0 ? (
+        <p className="text-sm text-slate-400">
+          Chronicle timeline events with dates to unlock how the world ages over centuries.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {currentAge && (
+            <div className="rounded-xl border border-violet-500/40 bg-violet-500/10 p-4 space-y-1.5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-violet-200">Current age</p>
+              <p className="text-lg font-semibold text-slate-100">{currentAge.label}</p>
+              <p className="text-sm text-slate-200">
+                Anchored by <span className="font-semibold">{currentAge.signature}</span>
+                {lastRecordedYear !== null ? ` · Last recorded year ${lastRecordedYear}` : ''}
+              </p>
+            </div>
+          )}
+          {upcomingAge && (
+            <div className="rounded-xl border border-amber-400/50 bg-amber-500/10 p-4 space-y-1.5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-amber-200">Projected next age</p>
+              <p className="text-base font-semibold text-slate-100">{upcomingAge.label}</p>
+              <p className="text-sm text-slate-200">
+                Awaiting key events to define this era&apos;s tone.
+              </p>
+            </div>
+          )}
+          <div className="space-y-3">
+            {eras.map((era) => (
+              <article
+                key={`${era.label}-${era.start}-${era.end}`}
+                className="rounded-lg border border-slate-700/60 bg-slate-900/70 p-3 space-y-1"
+              >
+                <div className="flex items-center justify-between text-sm text-slate-200">
+                  <span className="font-semibold">{era.label}</span>
+                  <span className="text-xs text-slate-400">
+                    {era.start}
+                    {era.end !== null && era.end !== era.start ? ` – ${era.end}` : ''}
+                  </span>
+                </div>
+                <p className="text-xs text-slate-400">{era.eventCount} documented event{era.eventCount === 1 ? '' : 's'}</p>
+                {era.relatedEventTitles.length > 0 && (
+                  <p className="text-xs text-slate-500">
+                    Highlights: {era.relatedEventTitles.join(' · ')}
+                  </p>
+                )}
+              </article>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const FactionColumn: React.FC<{
+  factions: FactionConflictSummary[];
+  onSelectArtifact: (artifactId: string) => void;
+}> = ({ factions, onSelectArtifact }) => (
+  <div className="space-y-4">
+    <div className="flex items-center gap-2 text-slate-200">
+      <FlagIcon className="w-5 h-5 text-emerald-300" />
+      <h4 className="text-sm font-semibold uppercase tracking-wide text-slate-300">Faction & conflict web</h4>
+    </div>
+    {factions.length === 0 ? (
+      <p className="text-sm text-slate-400">
+        Map at least one faction artifact to begin tracking alliances and rivalries.
+      </p>
+    ) : (
+      <div className="space-y-3">
+        {factions.map((faction) => (
+          <article
+            key={faction.id}
+            className="rounded-xl border border-slate-700/60 bg-slate-900/70 p-4 space-y-3 shadow-lg shadow-slate-950/20"
+          >
+            <div className="flex items-start justify-between gap-2">
+              <div className="space-y-1">
+                <div className="flex items-center gap-2">
+                  <h5 className="text-base font-semibold text-slate-100">{faction.factionName}</h5>
+                  <span
+                    className={`inline-flex items-center gap-1 rounded-full px-2.5 py-0.5 text-[11px] font-semibold uppercase tracking-wide border ${STABILITY_STYLE[faction.stability]}`}
+                  >
+                    {faction.stability === 'stable'
+                      ? 'Stable'
+                      : faction.stability === 'shifting'
+                        ? 'Shifting'
+                        : 'Volatile'}
+                  </span>
+                </div>
+                <p className="text-sm text-slate-300">{faction.summary}</p>
+              </div>
+              <button
+                type="button"
+                onClick={() => onSelectArtifact(faction.relatedArtifactId)}
+                className="text-xs font-semibold text-cyan-300 hover:text-cyan-200"
+              >
+                Open
+              </button>
+            </div>
+            <div className="grid grid-cols-1 gap-3 text-xs text-slate-400 sm:grid-cols-3">
+              <FactionList title="Allies" items={faction.alliances} />
+              <FactionList title="Rivals" items={faction.rivalries} />
+              <FactionList title="Tensions" items={faction.tensions} />
+            </div>
+          </article>
+        ))}
+      </div>
+    )}
+  </div>
+);
+
+const FactionList: React.FC<{ title: string; items: string[] }> = ({ title, items }) => (
+  <div className="space-y-1">
+    <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-500">{title}</p>
+    {items.length === 0 ? (
+      <p className="text-xs text-slate-600">—</p>
+    ) : (
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li key={item} className="text-slate-300">
+            {item}
+          </li>
+        ))}
+      </ul>
+    )}
+  </div>
+);
+
+export default WorldSimulationPanel;

--- a/code/utils/worldSimulation.ts
+++ b/code/utils/worldSimulation.ts
@@ -1,0 +1,500 @@
+import {
+  Artifact,
+  ArtifactType,
+  LocationData,
+  MagicSystemData,
+  TimelineData,
+  TimelineEvent,
+} from '../types';
+
+export type ConstraintType = 'physics' | 'metaphysics';
+export type ConstraintStatus = 'stable' | 'volatile' | 'forbidden' | 'unknown';
+
+export interface ConstraintAnnotation {
+  id: string;
+  label: string;
+  type: ConstraintType;
+  status: ConstraintStatus;
+  summary: string;
+  detail?: string;
+  relatedArtifactIds: string[];
+}
+
+export interface WorldAgeSegment {
+  label: string;
+  start: number;
+  end: number | null;
+  eventCount: number;
+  signature: string;
+  relatedEventTitles: string[];
+}
+
+export interface WorldAgeProgression {
+  currentAge: WorldAgeSegment | null;
+  upcomingAge: WorldAgeSegment | null;
+  eras: WorldAgeSegment[];
+  lastRecordedYear: number | null;
+}
+
+export type FactionStability = 'stable' | 'shifting' | 'volatile';
+
+export interface FactionConflictSummary {
+  id: string;
+  factionName: string;
+  summary: string;
+  alliances: string[];
+  rivalries: string[];
+  tensions: string[];
+  stability: FactionStability;
+  relatedArtifactId: string;
+}
+
+export interface WorldSimulationSnapshot {
+  constraints: ConstraintAnnotation[];
+  ageProgression: WorldAgeProgression;
+  factions: FactionConflictSummary[];
+}
+
+interface TimelineEventWithMeta extends TimelineEvent {
+  artifactId: string;
+  year: number | null;
+}
+
+const STATUS_RANK: Record<ConstraintStatus, number> = {
+  forbidden: 0,
+  volatile: 1,
+  stable: 2,
+  unknown: 3,
+};
+
+const ERA_LABELS = ['Founding Age', 'Expansion Era', 'Flux Cycle', 'Apex Horizon'];
+
+const ALLIANCE_KINDS = new Set(['ALLY_OF', 'SUPPORTS', 'TRADE_PARTNER', 'PROTECTS']);
+const RIVAL_KINDS = new Set(['ENEMY_OF', 'AT_WAR_WITH', 'OPPOSED_TO', 'RIVAL']);
+const TENSION_KINDS = new Set(['INFLUENCES', 'PRESSURES', 'TENSIONS_WITH', 'COMPETING_FOR']);
+
+const VOLATILE_KEYWORDS = /(volatile|unstable|danger|backlash|cataclysm|fracture|feral|sacrifice|shatter|scar|threat)/i;
+const FORBIDDEN_KEYWORDS = /(forbidden|taboo|never|prohibited|ban|do not)/i;
+const METAPHYSICS_KEYWORDS = /(magic|thread|ritual|soul|veil|ley|spirit|arcane|astral|mana|curse)/i;
+const PHYSICS_KEYWORDS = /(gravity|storm|pressure|radiation|tectonic|clockwork|gear|machine|technology|desert|flood|climate|storm)/i;
+
+const sanitizeText = (value: string | undefined | null): string => value?.trim() ?? '';
+
+const detectStatusFromText = (text: string, fallback: ConstraintStatus): ConstraintStatus => {
+  if (FORBIDDEN_KEYWORDS.test(text)) {
+    return 'forbidden';
+  }
+  if (VOLATILE_KEYWORDS.test(text)) {
+    return 'volatile';
+  }
+  return fallback;
+};
+
+const detectConstraintType = (text: string, explicitType?: ConstraintType): ConstraintType => {
+  if (explicitType) {
+    return explicitType;
+  }
+  if (METAPHYSICS_KEYWORDS.test(text) && !PHYSICS_KEYWORDS.test(text)) {
+    return 'metaphysics';
+  }
+  if (PHYSICS_KEYWORDS.test(text)) {
+    return 'physics';
+  }
+  return 'metaphysics';
+};
+
+const parseChronoValue = (value: string): number | null => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const direct = Number.parseFloat(trimmed);
+  if (!Number.isNaN(direct)) {
+    return direct;
+  }
+
+  const iso = Date.parse(trimmed);
+  if (!Number.isNaN(iso)) {
+    return new Date(iso).getFullYear();
+  }
+
+  const match = trimmed.match(/-?\d{1,4}/);
+  if (match) {
+    const parsed = Number.parseInt(match[0] ?? '', 10);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const buildMagicSystemConstraints = (
+  artifact: Artifact,
+  data: MagicSystemData,
+): ConstraintAnnotation[] => {
+  const annotations: ConstraintAnnotation[] = [];
+
+  for (const principle of data.principles) {
+    const focus = sanitizeText(principle.focus);
+    const description = sanitizeText(principle.description);
+    const combined = `${focus} ${description}`.trim();
+    const status = principle.stability ?? 'stable';
+    const inferredStatus = detectStatusFromText(combined, status);
+    annotations.push({
+      id: `${artifact.id}-principle-${principle.id}`,
+      label: principle.title,
+      type: 'metaphysics',
+      status: inferredStatus,
+      summary: focus || description || 'Document the governing principle.',
+      detail: description && description !== focus ? description : undefined,
+      relatedArtifactIds: [artifact.id],
+    });
+  }
+
+  for (const source of data.sources) {
+    const combined = `${source.resonance} ${source.capacity} ${source.tells}`;
+    const status = detectStatusFromText(combined, 'stable');
+    annotations.push({
+      id: `${artifact.id}-source-${source.id}`,
+      label: source.name,
+      type: 'metaphysics',
+      status,
+      summary: sanitizeText(source.resonance) || 'Describe the resonance signature.',
+      detail: sanitizeText(source.capacity) || undefined,
+      relatedArtifactIds: [artifact.id],
+    });
+  }
+
+  for (const ritual of data.rituals) {
+    const combined = `${ritual.effect} ${ritual.failure}`;
+    const status = detectStatusFromText(combined, 'stable');
+    annotations.push({
+      id: `${artifact.id}-ritual-${ritual.id}`,
+      label: ritual.name,
+      type: 'metaphysics',
+      status,
+      summary: sanitizeText(ritual.effect) || 'Document what the ritual achieves.',
+      detail: sanitizeText(ritual.cost) || undefined,
+      relatedArtifactIds: [artifact.id],
+    });
+  }
+
+  for (const taboo of data.taboos) {
+    const combined = `${taboo.rule} ${taboo.consequence}`;
+    const status = detectStatusFromText(combined, 'forbidden');
+    annotations.push({
+      id: `${artifact.id}-taboo-${taboo.id}`,
+      label: taboo.rule,
+      type: 'metaphysics',
+      status,
+      summary: sanitizeText(taboo.consequence) || 'Note the backlash for breaking this taboo.',
+      detail: sanitizeText(taboo.restoration) || undefined,
+      relatedArtifactIds: [artifact.id],
+    });
+  }
+
+  data.fieldNotes.forEach((note, index) => {
+    const status = detectStatusFromText(note, 'stable');
+    annotations.push({
+      id: `${artifact.id}-note-${index}`,
+      label: 'Field Note',
+      type: 'metaphysics',
+      status,
+      summary: note,
+      relatedArtifactIds: [artifact.id],
+    });
+  });
+
+  return annotations;
+};
+
+const buildLocationConstraints = (artifact: Artifact, data: LocationData): ConstraintAnnotation[] => {
+  const annotations: ConstraintAnnotation[] = [];
+  const baseDescription = sanitizeText(data.description);
+  if (baseDescription) {
+    const status = detectStatusFromText(baseDescription, 'stable');
+    annotations.push({
+      id: `${artifact.id}-environment`,
+      label: `${artifact.title} environment`,
+      type: detectConstraintType(baseDescription, PHYSICS_KEYWORDS.test(baseDescription) ? 'physics' : undefined),
+      status,
+      summary: baseDescription,
+      relatedArtifactIds: [artifact.id],
+    });
+  }
+
+  data.features.forEach((feature) => {
+    const description = sanitizeText(feature.description);
+    const status = detectStatusFromText(description, 'stable');
+    const type = detectConstraintType(`${feature.name} ${description}`, undefined);
+    annotations.push({
+      id: `${artifact.id}-feature-${feature.id}`,
+      label: feature.name,
+      type,
+      status,
+      summary: description || 'Describe how this feature alters local conditions.',
+      relatedArtifactIds: [artifact.id],
+    });
+  });
+
+  return annotations;
+};
+
+const buildTimelineConstraints = (
+  artifact: Artifact,
+  data: TimelineData,
+): ConstraintAnnotation[] => {
+  const annotations: ConstraintAnnotation[] = [];
+
+  data.events.forEach((event) => {
+    const combined = `${event.title} ${event.description}`;
+    const status = detectStatusFromText(combined, 'stable');
+    const type = detectConstraintType(combined, undefined);
+    if (status === 'stable' && type === 'metaphysics') {
+      // Skip benign notes to avoid noise.
+      return;
+    }
+
+    annotations.push({
+      id: `${artifact.id}-event-${event.id}`,
+      label: event.title,
+      type,
+      status,
+      summary: sanitizeText(event.description) || 'Timeline event affecting systemic constraints.',
+      detail: sanitizeText(event.date),
+      relatedArtifactIds: [artifact.id],
+    });
+  });
+
+  return annotations;
+};
+
+const buildTimelineEvents = (artifact: Artifact, data: TimelineData): TimelineEventWithMeta[] =>
+  data.events.map((event) => ({
+    ...event,
+    artifactId: artifact.id,
+    year: parseChronoValue(event.date ?? ''),
+  }));
+
+const resolveEraLabel = (index: number): string => ERA_LABELS[index] ?? `Age ${index + 1}`;
+
+const summarizeEvents = (events: TimelineEventWithMeta[]): string[] => {
+  if (events.length === 0) {
+    return [];
+  }
+  const highlights = events.slice(-2).map((event) => `${event.title}${event.date ? ` (${event.date})` : ''}`);
+  return highlights;
+};
+
+const buildWorldAgeProgression = (events: TimelineEventWithMeta[]): WorldAgeProgression => {
+  const datedEvents = events.filter((event) => event.year !== null).sort((a, b) => (a.year! - b.year!));
+  if (datedEvents.length === 0) {
+    return {
+      currentAge: null,
+      upcomingAge: null,
+      eras: [],
+      lastRecordedYear: null,
+    };
+  }
+
+  const firstYear = datedEvents[0]!.year!;
+  const lastYear = datedEvents[datedEvents.length - 1]!.year!;
+  const span = Math.max(1, lastYear - firstYear);
+
+  let bucketCount = 1;
+  if (span > 0 && datedEvents.length >= 2) {
+    bucketCount = 2;
+  }
+  if (span > 150 && datedEvents.length >= 3) {
+    bucketCount = 3;
+  }
+  if (span > 400 && datedEvents.length >= 4) {
+    bucketCount = 4;
+  }
+
+  const step = Math.max(1, Math.ceil(span / bucketCount));
+  const buckets = Array.from({ length: bucketCount }, (_, index) => ({
+    start: firstYear + index * step,
+    end: index === bucketCount - 1 ? lastYear : firstYear + (index + 1) * step - 1,
+    events: [] as TimelineEventWithMeta[],
+  }));
+
+  datedEvents.forEach((event) => {
+    const offset = event.year! - firstYear;
+    const bucketIndex = Math.min(bucketCount - 1, span === 0 ? 0 : Math.floor(offset / step));
+    buckets[bucketIndex]!.events.push(event);
+  });
+
+  const eras: WorldAgeSegment[] = buckets.map((bucket, index) => {
+    const signatureEvent = bucket.events[bucket.events.length - 1];
+    return {
+      label: resolveEraLabel(index),
+      start: bucket.start,
+      end: bucket.end,
+      eventCount: bucket.events.length,
+      signature: signatureEvent
+        ? `${signatureEvent.title}${signatureEvent.date ? ` (${signatureEvent.date})` : ''}`
+        : 'Awaiting chronicle',
+      relatedEventTitles: summarizeEvents(bucket.events),
+    };
+  });
+
+  const currentIndex = buckets.reduce((latest, bucket, index) => (bucket.events.length > 0 ? index : latest), 0);
+  const currentAge = eras[currentIndex] ?? null;
+  const upcomingAge = eras[currentIndex + 1] ?? null;
+
+  return {
+    currentAge,
+    upcomingAge,
+    eras,
+    lastRecordedYear: lastYear,
+  };
+};
+
+const determineFactionStability = (artifact: Artifact, alliances: string[], rivalries: string[], tensions: string[]): FactionStability => {
+  const tensionScore = rivalries.length * 2 + tensions.length;
+  const allianceScore = alliances.length;
+  const summary = `${artifact.summary} ${artifact.tags.join(' ')}`;
+  if (VOLATILE_KEYWORDS.test(summary)) {
+    return 'volatile';
+  }
+  if (tensionScore === 0) {
+    return 'stable';
+  }
+  if (tensionScore > allianceScore + 1) {
+    return 'volatile';
+  }
+  if (tensionScore > allianceScore) {
+    return 'shifting';
+  }
+  return 'stable';
+};
+
+const buildFactionSummaries = (artifacts: Artifact[]): FactionConflictSummary[] => {
+  const indexById = new Map<string, Artifact>(artifacts.map((artifact) => [artifact.id, artifact]));
+  return artifacts
+    .filter((artifact) => artifact.type === ArtifactType.Faction)
+    .map((artifact) => {
+      const alliances: string[] = [];
+      const rivalries: string[] = [];
+      const tensions: string[] = [];
+
+      artifact.relations.forEach((relation) => {
+        const targetTitle = indexById.get(relation.toId)?.title ?? relation.toId;
+        if (ALLIANCE_KINDS.has(relation.kind)) {
+          alliances.push(targetTitle);
+        } else if (RIVAL_KINDS.has(relation.kind)) {
+          rivalries.push(targetTitle);
+        } else if (TENSION_KINDS.has(relation.kind)) {
+          tensions.push(targetTitle);
+        }
+      });
+
+      const stability = determineFactionStability(artifact, alliances, rivalries, tensions);
+      const parts: string[] = [];
+      if (alliances.length > 0) {
+        parts.push(`Allies: ${alliances.join(', ')}`);
+      }
+      if (rivalries.length > 0) {
+        parts.push(`Rivals: ${rivalries.join(', ')}`);
+      }
+      if (tensions.length > 0) {
+        parts.push(`Tensions: ${tensions.join(', ')}`);
+      }
+      const summary = parts.join(' · ') || 'No recorded alliances or conflicts yet.';
+
+      return {
+        id: artifact.id,
+        factionName: artifact.title,
+        summary,
+        alliances,
+        rivalries,
+        tensions,
+        stability,
+        relatedArtifactId: artifact.id,
+      };
+    })
+    .sort((a, b) => {
+      const stabilityRank: Record<FactionStability, number> = { stable: 2, shifting: 1, volatile: 0 };
+      const rankDiff = stabilityRank[a.stability] - stabilityRank[b.stability];
+      if (rankDiff !== 0) {
+        return rankDiff;
+      }
+      return a.factionName.localeCompare(b.factionName);
+    });
+};
+
+export const deriveWorldSimulationSnapshot = (artifacts: Artifact[]): WorldSimulationSnapshot => {
+  const constraints: ConstraintAnnotation[] = [];
+  let allTimelineEvents: TimelineEventWithMeta[] = [];
+
+  for (const artifact of artifacts) {
+    switch (artifact.type) {
+      case ArtifactType.MagicSystem: {
+        const data = artifact.data as MagicSystemData | undefined;
+        if (data) {
+          constraints.push(...buildMagicSystemConstraints(artifact, data));
+        }
+        break;
+      }
+      case ArtifactType.Location: {
+        const data = artifact.data as LocationData | undefined;
+        if (data) {
+          constraints.push(...buildLocationConstraints(artifact, data));
+        }
+        break;
+      }
+      case ArtifactType.Timeline: {
+        const data = artifact.data as TimelineData | undefined;
+        if (data) {
+          allTimelineEvents = allTimelineEvents.concat(buildTimelineEvents(artifact, data));
+          constraints.push(...buildTimelineConstraints(artifact, data));
+        }
+        break;
+      }
+      case ArtifactType.Wiki: {
+        const content = typeof artifact.data === 'object' && artifact.data && 'content' in artifact.data
+          ? sanitizeText((artifact.data as { content?: string }).content)
+          : '';
+        if (content) {
+          const status = detectStatusFromText(content, 'stable');
+          if (status !== 'stable') {
+            constraints.push({
+              id: `${artifact.id}-wiki-constraint`,
+              label: artifact.title,
+              type: detectConstraintType(content, undefined),
+              status,
+              summary: content.slice(0, 160),
+              relatedArtifactIds: [artifact.id],
+            });
+          }
+        }
+        break;
+      }
+      default:
+        break;
+    }
+  }
+
+  constraints.sort((a, b) => {
+    const statusDiff = STATUS_RANK[a.status] - STATUS_RANK[b.status];
+    if (statusDiff !== 0) {
+      return statusDiff;
+    }
+    if (a.type !== b.type) {
+      return a.type.localeCompare(b.type);
+    }
+    return a.label.localeCompare(b.label);
+  });
+
+  const ageProgression = buildWorldAgeProgression(allTimelineEvents);
+  const factions = buildFactionSummaries(artifacts);
+
+  return {
+    constraints,
+    ageProgression,
+    factions,
+  };
+};


### PR DESCRIPTION
## Summary
- derive simulation insights from project artifacts including constraints, world ages, and faction stability
- introduce a WorldSimulationPanel component to visualize the annotations and interactions
- surface the panel in the project workspace so creators can jump from insights to artifact details

## Testing
- npm run lint --prefix code

------
https://chatgpt.com/codex/tasks/task_e_690bb5efa6408328b74bdff7d90c25e7